### PR TITLE
specify full path for String

### DIFF
--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -81,7 +81,7 @@ pub fn derive_json_schema(input: proc_macro::TokenStream) -> proc_macro::TokenSt
     let impl_block = quote! {
         #[automatically_derived]
         impl #impl_generics schemars::JsonSchema for #type_name #ty_generics #where_clause {
-            fn schema_name() -> String {
+            fn schema_name() -> std::string::String {
                 #schema_name
             }
 


### PR DESCRIPTION
Hi. Thanks for your awesome work!

It would be error if a user uses their own `String` type. Actually, I got an error.

I haven't fully searched code base for another place not using absolute path yet.

Thanks.