### PR TITLE
"additionalProperties: true" for struct tagged with "#[serde(deny_unknown_fields)]"

### DIFF
--- a/schemars/tests/expected/struct-normal-additional-properties.json
+++ b/schemars/tests/expected/struct-normal-additional-properties.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Struct",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "bar",
+    "foo"
+  ],
+  "properties": {
+    "bar": {
+      "type": "boolean"
+    },
+    "baz": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "foo": {
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/schemars/tests/struct_additional_properties.rs
+++ b/schemars/tests/struct_additional_properties.rs
@@ -1,0 +1,16 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+#[derive(Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Struct {
+    foo: i32,
+    bar: bool,
+    baz: Option<String>,
+}
+
+#[test]
+fn struct_normal_additional_properties() -> TestResult {
+    test_default_generated_schema::<Struct>("struct-normal-additional-properties")
+}

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -8,8 +8,7 @@ use syn::{Attribute, Data, Field, Meta, NestedMeta, Variant};
 static SERDE_KEYWORDS: &[&str] = &[
     "rename",
     "rename_all",
-    // TODO: for structs with `deny_unknown_fields`, set schema's `additionalProperties` to false.
-    // "deny_unknown_fields",
+    "deny_unknown_fields",
     "tag",
     "content",
     "untagged",

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -303,11 +303,22 @@ fn expr_for_struct(fields: &[Field], cattrs: Option<&serde_attr::Container>) -> 
         }
     });
 
+    let additional_properties = cattrs
+        .map_or(false, |attrs| attrs.deny_unknown_fields());
+
     quote! {
         {
             #set_container_default
             let mut schema_object = schemars::schema::SchemaObject {
                 instance_type: Some(schemars::schema::InstanceType::Object.into()),
+                object: Some(Box::new(schemars::schema::ObjectValidation {
+                    additional_properties: if #additional_properties {
+                        Some(Box::new(#additional_properties.into()))
+                    } else {
+                        None
+                    },
+                    ..Default::default()
+                })),
                 ..Default::default()
             };
             #(#properties)*


### PR DESCRIPTION
Mentioned in #27 as well as `TODO` in the code.

If `#[serde(deny_unknown_fields)]` is not specified, default behavior (as with `additionalProperties: true`, i.e. properties are allowed but skipped).