### PR TITLE
Adding `IndexMap` under feature flag `preserve_order`

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 chrono = { version = "0.4", default-features = false, optional = true }
-indexmap = { version = "1.2", optional = true }
+indexmap = { version = "1.2", features=["serde-1"], optional = true }
 either = { version = "1.3", default-features = false, optional = true }
 uuid = { version = "0.8", default-features = false, optional = true }
 smallvec = { version = "1.0", optional = true }
@@ -31,6 +31,11 @@ pretty_assertions = "0.6.1"
 default = ["derive"]
 
 derive = ["schemars_derive"]
+
+# Use a different representation for the map type of Schemars.
+# This allows data to be read into a Value and written back to a JSON string
+# while preserving the order of map keys in the input.
+preserve_order = ["indexmap"]
 
 impl_json_schema = ["derive"]
 # derive_json_schema will be removed in a later version

--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -101,9 +101,20 @@ impl<T> Merge for Vec<T> {
     }
 }
 
-impl<K: Ord, V> Merge for Map<K, V> {
+impl<K, V> Merge for Map<K, V>
+where
+    K: std::hash::Hash + Eq + Ord,
+{
     fn merge(mut self, other: Self) -> Self {
-        self.extend(other);
+        // IndexMap only implements `Extens<(K, V)>` for `IndexMap<K, V, S>`
+        // `where K: Hash + Eq + Copy, V: Copy,`
+        // The `K: Copy` and `V: Copy` traits are not implemented for things like `String`
+        // Because of this I made a simple extend implementation here.
+        // self.extend(other);
+        // Basic replacement for extend.
+        for (key, value) in other {
+            self.insert(key, value);
+        }
         self
     }
 }

--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -106,15 +106,7 @@ where
     K: std::hash::Hash + Eq + Ord,
 {
     fn merge(mut self, other: Self) -> Self {
-        // IndexMap only implements `Extens<(K, V)>` for `IndexMap<K, V, S>`
-        // `where K: Hash + Eq + Copy, V: Copy,`
-        // The `K: Copy` and `V: Copy` traits are not implemented for things like `String`
-        // Because of this I made a simple extend implementation here.
-        // self.extend(other);
-        // Basic replacement for extend.
-        for (key, value) in other {
-            self.insert(key, value);
-        }
+        self.extend(other);
         self
     }
 }

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -225,21 +225,13 @@ pub type Map<K, V> = indexmap::IndexMap<K, V>;
 /// with a similar interface in a future version of schemars.
 pub type Set<T> = std::collections::BTreeSet<T>;
 
+/// A view into a single entry in a map, which may either be vacant or occupied.
+/// This `enum` is constructed from the `entry` method on `BTreeMap` or `IndexMap` 
+/// depending on the `preserve_order` feature flag.
 #[cfg(not(feature = "preserve_order"))]
 pub type MapEntry<'a, K, V> = std::collections::btree_map::Entry<'a, K, V>;
 #[cfg(feature = "preserve_order")]
 pub type MapEntry<'a, K, V> = indexmap::map::Entry<'a, K, V>;
-
-#[cfg(not(feature = "preserve_order"))]
-pub type AltMap<K, V> = std::collections::HashMap<K, V>;
-#[cfg(feature = "preserve_order")]
-pub type AltMap<K, V> = indexmap::IndexMap<K, V>;
-
-#[cfg(not(feature = "preserve_order"))]
-pub type AltMapEntry<'a, K, V> = std::collections::hash_map::Entry<'a, K, V>;
-#[cfg(feature = "preserve_order")]
-pub type AltMapEntry<'a, K, V> = indexmap::map::Entry<'a, K, V>;
-
 
 mod flatten;
 mod json_schema_impls;

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -197,8 +197,9 @@ fn main() {
 `#[serde(...)]` attributes can be overriden using `#[schemars(...)]` attributes, which behave identically (e.g. `#[schemars(rename_all = "camelCase")]`). You may find this useful if you want to change the generated schema without affecting Serde's behaviour, or if you're just not using Serde.
 
 ## Feature Flags
-- `derive` (enabled by default) - provides `#[derive(JsonSchema)]` macro
-- `impl_json_schema` - implements `JsonSchema` for Schemars types themselves
+- `derive` (enabled by default) - provides `#[derive(JsonSchema)]` macro.
+- `impl_json_schema` - implements `JsonSchema` for Schemars types themselves.
+- `preserve_order` - keep the order of structure fields in `Schema` and `SchemaObject`.
 
 ## Optional Dependencies
 Schemars can implement `JsonSchema` on types from several popular crates, enabled via optional dependencies (dependency versions are shown in brackets):

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -213,22 +213,22 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 
 /// The map type used by schemars types.
 ///
-/// Currently a `BTreeMap` or `IndexMap` can be used, but this may change a different implementation
-/// The `IndexMap` will be used when the `preserve_order` feature flag is set.
+/// Currently a `BTreeMap` or `IndexMap` can be used, but this may change to a different implementation
 /// with a similar interface in a future version of schemars.
+/// The `IndexMap` will be used when the `preserve_order` feature flag is set.
 #[cfg(not(feature = "preserve_order"))]
 pub type Map<K, V> = std::collections::BTreeMap<K, V>;
 #[cfg(feature = "preserve_order")]
 pub type Map<K, V> = indexmap::IndexMap<K, V>;
 /// The set type used by schemars types.
 ///
-/// Currently a `BTreeSet`, but this may change a different implementation
+/// Currently a `BTreeSet`, but this may change to a different implementation
 /// with a similar interface in a future version of schemars.
 pub type Set<T> = std::collections::BTreeSet<T>;
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
-/// This `enum` is constructed from the `entry` method on `BTreeMap` or `IndexMap` 
-/// depending on the `preserve_order` feature flag.
+/// This is constructed from the `entry` method on `BTreeMap` or `IndexMap`
+/// depending on whether the `preserve_order` feature flag is set.
 #[cfg(not(feature = "preserve_order"))]
 pub type MapEntry<'a, K, V> = std::collections::btree_map::Entry<'a, K, V>;
 #[cfg(feature = "preserve_order")]

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -225,6 +225,22 @@ pub type Map<K, V> = indexmap::IndexMap<K, V>;
 /// with a similar interface in a future version of schemars.
 pub type Set<T> = std::collections::BTreeSet<T>;
 
+#[cfg(not(feature = "preserve_order"))]
+pub type MapEntry<'a, K, V> = std::collections::btree_map::Entry<'a, K, V>;
+#[cfg(feature = "preserve_order")]
+pub type MapEntry<'a, K, V> = indexmap::map::Entry<'a, K, V>;
+
+#[cfg(not(feature = "preserve_order"))]
+pub type AltMap<K, V> = std::collections::HashMap<K, V>;
+#[cfg(feature = "preserve_order")]
+pub type AltMap<K, V> = indexmap::IndexMap<K, V>;
+
+#[cfg(not(feature = "preserve_order"))]
+pub type AltMapEntry<'a, K, V> = std::collections::hash_map::Entry<'a, K, V>;
+#[cfg(feature = "preserve_order")]
+pub type AltMapEntry<'a, K, V> = indexmap::map::Entry<'a, K, V>;
+
+
 mod flatten;
 mod json_schema_impls;
 #[macro_use]

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -212,9 +212,13 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 
 /// The map type used by schemars types.
 ///
-/// Currently a `BTreeMap`, but this may change a different implementation
+/// Currently a `BTreeMap` or `IndexMap` can be used, but this may change a different implementation
+/// The `IndexMap` will be used when the `preserve_order` feature flag is set.
 /// with a similar interface in a future version of schemars.
+#[cfg(not(feature = "preserve_order"))]
 pub type Map<K, V> = std::collections::BTreeMap<K, V>;
+#[cfg(feature = "preserve_order")]
+pub type Map<K, V> = indexmap::IndexMap<K, V>;
 /// The set type used by schemars types.
 ///
 /// Currently a `BTreeSet`, but this may change a different implementation


### PR DESCRIPTION
WIP: Do not merge yet
Implementation for #32 

This is only a small change.
Most of the change is to make `impl<K, V> Merge for Map<K, V>` work again.
Because the `Extens<(K, V)>` for `IndexMap<K, V, S>` implementation relays on `K: Hash + Eq + Copy, V: Copy,` As Copy is not always implemented for things like String and most structs. So I make a small implementation of `extend` in there. With `insert` that only needs to relays `K: std::hash::Hash + Eq`. The `Ord` trait was already there. Just moved it down.

## Tested
I tested the code both in the okapi example and my code. Both work with and without the feature flag set.

## Import in code
When testing make sure you point `okapi`,`rocket-okapi` and your own code to the same `Schemars` version.

Example in my code (and okapi example): (Cargo.toml)
```toml
# My normal way of importing schemars
schemars = "0.7"
# With feature flag pointing to my local copy.
schemars = { version = "0.7.0", 
path = "path_to_somewhere/schemars/schemars", features = ["preserve_order"] }
# Without the feature flag.
schemars = { version = "0.7.0", 
path = "path_to_somewhere/schemars/schemars", features = [] }
```

## Weird API call list order
The only odd behavior that I have noticed is that the order of the api calls is not consistent.
Order without feature flag:
![Screenshot from 2020-05-26 23-42-37](https://user-images.githubusercontent.com/2608639/82953510-2f4cae80-9fab-11ea-8b92-409108b6f9d7.png)
Order with flag run first time:
![Screenshot from 2020-05-26 23-47-27](https://user-images.githubusercontent.com/2608639/82953604-586d3f00-9fab-11ea-9a06-8a979f49e22a.png)
Close and run again:
![Screenshot from 2020-05-26 23-47-37](https://user-images.githubusercontent.com/2608639/82953619-5f944d00-9fab-11ea-9ebf-d8f553ef38bb.png)

This is different every time you close and start the server again (does not even have to recompile).
I do not know how this comes. But also have not looked into this yet.
The order in the rocket output is always the same.
I have only seen this with the routes not the other parts.
Order changes in json as you can see here (both with feature flag, just closed and started server in between):
![Screenshot from 2020-05-26 23-55-36](https://user-images.githubusercontent.com/2608639/82954179-80a96d80-9fac-11ea-9268-1789c0f45f08.png)
![Screenshot from 2020-05-26 23-55-58](https://user-images.githubusercontent.com/2608639/82954184-830bc780-9fac-11ea-92f3-24d210382a28.png)

## Works, proof
But here is proof that is works in other cases:
![Without feature flag](https://user-images.githubusercontent.com/2608639/82953469-1fcd6580-9fab-11ea-87f5-5a9ae1e60c5a.png)
With flag:
![Screenshot from 2020-05-26 23-48-52](https://user-images.githubusercontent.com/2608639/82953680-83579300-9fab-11ea-92a8-186d4ca71c8f.png)

## Feedback
So what do you think? What can be changes/improved. You maybe have an idea where the order bug comes from? Maybe just timing or multi-threading?

@ThouCheese are you maybe willing to give this a try in your project to see if you spot any compatibility error?
