### PR TITLE
Remove Any bound from Visitor

### DIFF
--- a/schemars/src/gen.rs
+++ b/schemars/src/gen.rs
@@ -101,7 +101,7 @@ impl SchemaSettings {
     }
 
     /// TODO document
-    pub fn with_visitor(mut self, visitor: impl Visitor) -> Self {
+    pub fn with_visitor(mut self, visitor: impl Visitor + 'static) -> Self {
         self.visitors.0.push(Arc::new(visitor));
         self
     }

--- a/schemars/src/visit.rs
+++ b/schemars/src/visit.rs
@@ -1,7 +1,7 @@
 use crate::schema::{RootSchema, Schema, SchemaObject, SingleOrVec};
-use std::{any::Any, fmt::Debug};
+use std::fmt::Debug;
 
-pub trait Visitor: Debug + Any {
+pub trait Visitor: Debug {
     fn visit_root_schema(&self, root: &mut RootSchema) {
         visit_root_schema(self, root)
     }


### PR DESCRIPTION
The `Any` bound on `Visitor` directly might be unnecessarily limiting. 

I was going to use it to resolve $refs in schemas, in that case I would need it to be mutable as well. Is there a reason why they're stored in an Arc?

I don't know what your plans are with `Visitor`, but if it for any kind of generic schema traversal, I believe it should be less constrained. Otherwise feel free to just close this.