### PR TITLE
Option to preserve formatting

### DIFF
--- a/schemars/tests/docs.rs
+++ b/schemars/tests/docs.rs
@@ -51,6 +51,16 @@ pub enum MyEnum {
     },
 }
 
+/// This
+/// is
+/// not
+///                         a
+/// single
+/// line.
+#[derive(JsonSchema)]
+#[schemars_preserve_doc_formatting]
+pub struct MyPreserveFormattingStruct;
+
 #[test]
 fn doc_comments_struct() -> TestResult {
     test_default_generated_schema::<MyStruct>("doc_comments_struct")
@@ -65,6 +75,11 @@ fn doc_comments_struct_ref_siblings() -> TestResult {
 #[test]
 fn doc_comments_enum() -> TestResult {
     test_default_generated_schema::<MyEnum>("doc_comments_enum")
+}
+
+#[test]
+fn doc_comments_preserve_formatting() -> TestResult {
+    test_default_generated_schema::<MyPreserveFormattingStruct>("doc_comments_preserve_formatting")
 }
 
 /// # OverrideDocs struct

--- a/schemars/tests/expected/doc_comments_preserve_formatting.json
+++ b/schemars/tests/expected/doc_comments_preserve_formatting.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MyPreserveFormattingStruct",
+  "description": "This\nis\nnot\n                        a\nsingle\nline.",
+  "type": "null"
+}

--- a/schemars_derive/src/attr/doc.rs
+++ b/schemars_derive/src/attr/doc.rs
@@ -67,8 +67,6 @@ fn get_doc(attrs: &[Attribute], preserve_formatting: bool) -> Option<String> {
             .skip_while(|s| *s == "")
             .collect::<Vec<_>>()
             .join("\n")
-    } else if !doc.is_empty() && doc.iter().all(|line| line.starts_with(' ')) {
-        doc.iter().map(|line| &line[1..]).collect::<Vec<_>>().join("\n")
     } else {
         doc.join("\n")
     };

--- a/schemars_derive/src/attr/doc.rs
+++ b/schemars_derive/src/attr/doc.rs
@@ -22,7 +22,10 @@ pub fn get_title_and_desc_from_doc(attrs: &[Attribute]) -> (Option<String>, Opti
     };
 
     if !preserve_formatting {
-        maybe_desc = maybe_desc.as_ref().map(String::as_str).and_then(merge_description_lines);
+        maybe_desc = maybe_desc
+            .as_ref()
+            .map(String::as_str)
+            .and_then(merge_description_lines);
     }
 
     (title, maybe_desc)
@@ -39,7 +42,9 @@ fn merge_description_lines(doc: &str) -> Option<String> {
 }
 
 fn should_preserve_formatting(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|attr| attr.path.is_ident("schemars_preserve_doc_formatting"))
+    attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("schemars_preserve_doc_formatting"))
 }
 
 fn get_doc(attrs: &[Attribute], preserve_formatting: bool) -> Option<String> {
@@ -60,8 +65,7 @@ fn get_doc(attrs: &[Attribute], preserve_formatting: bool) -> Option<String> {
         .collect::<Vec<_>>();
 
     let doc = if !preserve_formatting {
-        doc
-            .iter()
+        doc.iter()
             .flat_map(|a| a.split('\n'))
             .map(str::trim)
             .skip_while(|s| *s == "")

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -12,7 +12,7 @@ mod schema_exprs;
 use ast::*;
 use proc_macro2::TokenStream;
 
-#[proc_macro_derive(JsonSchema, attributes(schemars, serde))]
+#[proc_macro_derive(JsonSchema, attributes(schemars, serde, schemars_preserve_doc_formatting))]
 pub fn derive_json_schema_wrapper(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     derive_json_schema(input).into()

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -12,7 +12,10 @@ mod schema_exprs;
 use ast::*;
 use proc_macro2::TokenStream;
 
-#[proc_macro_derive(JsonSchema, attributes(schemars, serde, schemars_preserve_doc_formatting))]
+#[proc_macro_derive(
+    JsonSchema,
+    attributes(schemars, serde, schemars_preserve_doc_formatting)
+)]
 pub fn derive_json_schema_wrapper(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     derive_json_schema(input).into()


### PR DESCRIPTION
I chose to implement this as a separate attribute to not collide with serde options (or imply that it's a valid serde option).