### PR TITLE
add support for serde_repr

### DIFF
--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -42,11 +42,19 @@ impl_merge!(SchemaObject {
 });
 
 impl Merge for Metadata {
+    /// Merge two instances of metadata, where for those fields for which it is meaningful, the
+    /// values of `other` are appended to `self`, and for the other fields, the values in `self`
+    /// take precendence.
     fn merge(self, other: Self) -> Self {
+        let descriptions: Vec<String> = vec![self.description, other.description]
+            .into_iter()
+            .flatten()
+            .collect();
+        let description = Some(descriptions.join("\n\n"));
         Metadata {
             id: self.id.or(other.id),
             title: self.title.or(other.title),
-            description: self.description.or(other.description),
+            description,
             default: self.default.or(other.default),
             deprecated: self.deprecated || other.deprecated,
             read_only: self.read_only || other.read_only,

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -73,6 +73,10 @@ impl<'a> Variant<'a> {
             _ => false,
         }
     }
+
+    pub fn ident(&self) -> &syn::Ident {
+        &self.ident
+    }
 }
 
 impl<'a> Field<'a> {

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -1,7 +1,7 @@
 mod doc;
 mod schemars_to_serde;
 
-pub use schemars_to_serde::process_serde_attrs;
+pub(crate) use schemars_to_serde::process_serde_attrs;
 
 use proc_macro2::{Group, Span, TokenStream, TokenTree};
 use quote::ToTokens;

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -117,7 +117,7 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) -> AttributeInfo {
     let repr_type = attrs
         .iter()
         .filter(|attr| attr.path.is_ident("repr"))
-        .map(|attr| {
+        .flat_map(|attr| {
             fn repr_inner(input: parse::ParseStream) -> parse::Result<syn::Ident> {
                 let ident;
                 parenthesized!(ident in input);
@@ -125,8 +125,7 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) -> AttributeInfo {
             }
             repr_inner.parse2(attr.tokens.clone()).ok()
         })
-        .next()
-        .flatten();
+        .next();
 
     AttributeInfo {
         repr_type,


### PR DESCRIPTION
This pull request adds preliminary support for `serde_repr` by adding a corresponding `JsonSchema_repr` macro as we discussed in #35. I say preliminary because it throws away all info encoded in the variable names. Ideally, when `JsonSchema_repr` is on an enum with for example:

```rust
#[derive(JsonSchema_repr)]
enum StatusCode {
    /// The process exited successfully.
    Success = 0,
    // variants ...
}
```
The documentation should say `"* 0 - Success: The process exited successfully."` I'm not too sure how to go about doing this however, so any guidance would be appreciated :).

Also, this is my first time working with the proc macro api, so I checked everything and it seemed to report okay error messages, but if there is something wrong, please let me know.