### PR TITLE
Support deny_unknown_fields for untagged enums

### DIFF
--- a/schemars/tests/enum.rs
+++ b/schemars/tests/enum.rs
@@ -79,6 +79,23 @@ fn enum_untagged() -> TestResult {
 }
 
 #[derive(Debug, JsonSchema)]
+#[serde(untagged)]
+#[schemars(deny_unknown_fields)]
+pub enum UntaggedDenyUnknownFields {
+    OneWay {
+        foo: i32,
+    },
+    OrTheOther {
+        bar: i32,
+    }
+}
+
+#[test]
+fn enum_untagged_deny_unknown_fields() -> TestResult {
+    test_default_generated_schema::<UntaggedDenyUnknownFields>("enum-untagged-deny-unknown-fields")
+}
+
+#[derive(Debug, JsonSchema)]
 #[schemars(tag = "t", content = "c")]
 pub enum Adjacent {
     UnitOne,

--- a/schemars/tests/expected/enum-untagged-deny-unknown-fields.json
+++ b/schemars/tests/expected/enum-untagged-deny-unknown-fields.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UntaggedDenyUnknownFields",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "bar"
+      ],
+      "properties": {
+        "bar": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}


### PR DESCRIPTION
This is the simplest fix for #46. It might be necessary to filter the container attributes passed to the inner structs but I'm not sure what that would entail.