### PR TITLE
Support generic default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.8.9] - **in-dev**
+### Changed:
+- Support generic default values in `default` attributes (https://github.com/GREsau/schemars/pull/83)
+
 ## [0.8.8] - 2021-11-25
 ### Added:
 - Implement `JsonSchema` for types from `rust_decimal` and `bigdecimal` crates (https://github.com/GREsau/schemars/pull/101)

--- a/schemars/tests/default.rs
+++ b/schemars/tests/default.rs
@@ -55,7 +55,7 @@ fn schema_default_values() -> TestResult {
     test_default_generated_schema::<MyStruct>("default")
 }
 
-#[derive(Default, Deserialize, Serialize, JsonSchema, Debug, PartialEq)]
+#[derive(JsonSchema, Debug)]
 pub struct StructWithGenericDefaults {
     #[serde(default = "Vec::new")]
     pub a_vec: Vec<String>,

--- a/schemars/tests/default.rs
+++ b/schemars/tests/default.rs
@@ -54,3 +54,14 @@ pub struct NotSerialize;
 fn schema_default_values() -> TestResult {
     test_default_generated_schema::<MyStruct>("default")
 }
+
+#[derive(Default, Deserialize, Serialize, JsonSchema, Debug, PartialEq)]
+pub struct StructWithGenericDefaults {
+    #[serde(default = "Vec::new")]
+    pub a_vec: Vec<String>,
+}
+
+#[test]
+fn schema_with_generic_default_value() -> TestResult {
+    test_default_generated_schema::<StructWithGenericDefaults>("generic_default")
+}

--- a/schemars/tests/expected/generic_default.json
+++ b/schemars/tests/expected/generic_default.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StructWithGenericDefaults",
+  "type": "object",
+  "properties": {
+    "a_vec": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -581,7 +581,7 @@ fn field_default_expr(field: &Field, container_has_default: bool) -> Option<Toke
             quote!(container_default.#member)
         }
         SerdeDefault::Default => quote!(<#ty>::default()),
-        SerdeDefault::Path(path) => quote!(#path()),
+        SerdeDefault::Path(path) => quote!(|| -> #ty { #path() }()),
     };
 
     let default_expr = match field.serde_attrs.skip_serializing_if() {

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -581,7 +581,7 @@ fn field_default_expr(field: &Field, container_has_default: bool) -> Option<Toke
             quote!(container_default.#member)
         }
         SerdeDefault::Default => quote!(<#ty>::default()),
-        SerdeDefault::Path(path) => quote!(|| -> #ty { #path() }()),
+        SerdeDefault::Path(path) => quote!({ #path() as #ty }),
     };
 
     let default_expr = match field.serde_attrs.skip_serializing_if() {


### PR DESCRIPTION
I'm trying to `derive(JsonSchema)` on a field with a default that relies
on type inference to determine it's return type.  This causes compile
errors because schemars calls the default function without providing
any types for inference to use.

This changes that - wraps the `default` in a closure with a defined
return value that it immediately calls.  Feels a bit hacky, but I
couldn't think of a better way to fix this.