### PR TITLE
Support sqlx::type::Json wrapper type

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -26,10 +26,12 @@ smallvec = { version = "1.0", optional = true }
 arrayvec = { version = "0.5", default-features = false, optional = true }
 url = { version = "2.0", default-features = false, optional = true }
 bytes = { version = "1.0", optional = true }
+sqlx = { version = "0.5", default-features = false, features=["json"], optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 trybuild = "1.0"
+sqlx = { version = "0.5", features=["runtime-async-std-native-tls", "json"] }
 
 [features]
 default = ["derive"]
@@ -86,6 +88,10 @@ required-features = ["ui_test"]
 [[test]]
 name = "url"
 required-features = ["url"]
+
+[[test]]
+name = "sqlx"
+required-features = ["sqlx"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -58,6 +58,8 @@ mod sequences;
 mod serdejson;
 #[cfg(feature = "smallvec")]
 mod smallvec;
+#[cfg(feature = "sqlx")]
+mod sqlx;
 mod time;
 mod tuple;
 #[cfg(feature = "url")]

--- a/schemars/src/json_schema_impls/sqlx.rs
+++ b/schemars/src/json_schema_impls/sqlx.rs
@@ -1,0 +1,6 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use sqlx::types::Json;
+
+forward_impl!((<T> JsonSchema for Json<T> where T: JsonSchema) => T);

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -269,6 +269,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`arrayvec`](https://crates.io/crates/arrayvec) (^0.5)
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
+- [`sqlx`](https://cates.io/crates/sqlx) (^0.5)
 */
 
 /// The map type used by schemars types.

--- a/schemars/tests/expected/sqlx.json
+++ b/schemars/tests/expected/sqlx.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "String",
+  "type": "string"
+}

--- a/schemars/tests/sqlx.rs
+++ b/schemars/tests/sqlx.rs
@@ -1,0 +1,8 @@
+mod util;
+use sqlx::types::Json;
+use util::*;
+
+#[test]
+fn sqlx() -> TestResult {
+    test_default_generated_schema::<Json<String>>("sqlx")
+}


### PR DESCRIPTION
The `sqlx` package has a wrapper `Json` type that indicates that a structure represented as JSON in an SQL query should be deserialized into the given type. This PR adds support for that type with a straightforward `forward_impl!` call.