### PR TITLE
Add support for ipnetwork types

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,4 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`arrayvec`](https://crates.io/crates/arrayvec) (^0.5)
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
+- [`ipnetwork`](https://crates.io/crates/ipnetwork) (^0.18)

--- a/docs/4-features.md
+++ b/docs/4-features.md
@@ -28,3 +28,4 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`arrayvec`](https://crates.io/crates/arrayvec) (^0.5)
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
+- [`ipnetwork`](https://crates.io/crates/ipnetwork) (^0.18)

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = { version = "1.0", optional = true }
 arrayvec = { version = "0.5", default-features = false, optional = true }
 url = { version = "2.0", default-features = false, optional = true }
 bytes = { version = "1.0", optional = true }
+ipnetwork = { version = "0.18", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
@@ -86,6 +87,10 @@ required-features = ["ui_test"]
 [[test]]
 name = "url"
 required-features = ["url"]
+
+[[test]]
+name = "ipnetwork"
+required-features = ["ipnetwork"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/ipnetwork.rs
+++ b/schemars/src/json_schema_impls/ipnetwork.rs
@@ -1,0 +1,86 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+
+impl JsonSchema for IpNetwork {
+    fn schema_name() -> String {
+        "IpNetwork".to_string()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            metadata: Some(Box::new(Metadata {
+                description: Some("Represents a generic network range. This type can have two variants: the v4 and the v6 case.".to_string()),
+                examples: vec![
+                    serde_json::to_value(IpNetwork::V4("192.168.0.0/24".parse().unwrap())),
+                    serde_json::to_value(IpNetwork::V6("fc00::/7".parse().unwrap())),
+                ].into_iter().flatten().collect(),
+                ..Default::default()
+            })),
+            subschemas: Some(Box::new(SubschemaValidation {
+                any_of: Some(vec![
+                    gen.subschema_for::<Ipv4Network>(),
+                    gen.subschema_for::<Ipv6Network>(),
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl JsonSchema for Ipv4Network {
+    fn schema_name() -> String {
+        "Ipv4Network".to_string()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            metadata: Some(Box::new(Metadata {
+                description: Some(
+                    "Represents a network range where the IP addresses are of v4".to_string(),
+                ),
+                examples: vec![serde_json::to_value(
+                    "192.168.0.0/24".parse::<Ipv4Network>().unwrap(),
+                )]
+                .into_iter()
+                .flatten()
+                .collect(),
+                ..Default::default()
+            })),
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("ipv4-cidr".to_string()),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl JsonSchema for Ipv6Network {
+    fn schema_name() -> String {
+        "Ipv6Network".to_string()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            metadata: Some(Box::new(Metadata {
+                description: Some(
+                    "Represents a network range where the IP addresses are of v6".to_string(),
+                ),
+                examples: vec![serde_json::to_value(
+                    "fc00::/7".parse::<Ipv6Network>().unwrap(),
+                )]
+                .into_iter()
+                .flatten()
+                .collect(),
+                ..Default::default()
+            })),
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("ipv6-cidr".to_string()),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -50,6 +50,8 @@ mod either;
 mod ffi;
 #[cfg(feature = "indexmap")]
 mod indexmap;
+#[cfg(feature = "ipnetwork")]
+mod ipnetwork;
 mod maps;
 mod nonzero_signed;
 mod nonzero_unsigned;

--- a/schemars/tests/expected/ipnetwork.json
+++ b/schemars/tests/expected/ipnetwork.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IpNetwork",
+  "description": "Represents a generic network range. This type can have two variants: the v4 and the v6 case.",
+  "examples": [
+    "192.168.0.0/24",
+    "fc00::/7"
+  ],
+  "anyOf": [
+    {
+      "$ref": "#/definitions/Ipv4Network"
+    },
+    {
+      "$ref": "#/definitions/Ipv6Network"
+    }
+  ],
+  "definitions": {
+    "Ipv4Network": {
+      "description": "Represents a network range where the IP addresses are of v4",
+      "examples": [
+        "192.168.0.0/24"
+      ],
+      "type": "string",
+      "format": "ipv4-cidr"
+    },
+    "Ipv6Network": {
+      "description": "Represents a network range where the IP addresses are of v6",
+      "examples": [
+        "fc00::/7"
+      ],
+      "type": "string",
+      "format": "ipv6-cidr"
+    }
+  }
+}

--- a/schemars/tests/ipnetwork.rs
+++ b/schemars/tests/ipnetwork.rs
@@ -1,0 +1,8 @@
+mod util;
+use ipnetwork::IpNetwork;
+use util::*;
+
+#[test]
+fn ipnetwork() -> TestResult {
+    test_default_generated_schema::<IpNetwork>("ipnetwork")
+}


### PR DESCRIPTION
Adds `JsonSchema` implementations for `IpNetwork`, `Ipv4Network` and `Ipv6Network` from the [ipnetwork crate](https://crates.io/crates/ipnetwork).