### PR TITLE
JsonSchema implementation for MacAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,4 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`arrayvec`](https://crates.io/crates/arrayvec) (^0.5)
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
+- [`mac_address`](https://crates.io/crates/mac_address) (^1.1)

--- a/docs/4-features.md
+++ b/docs/4-features.md
@@ -28,3 +28,4 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`arrayvec`](https://crates.io/crates/arrayvec) (^0.5)
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
+- [`mac_address`](https://crates.io/crates/mac_address) (^1.1)

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -26,6 +26,7 @@ smallvec = { version = "1.0", optional = true }
 arrayvec = { version = "0.5", default-features = false, optional = true }
 url = { version = "2.0", default-features = false, optional = true }
 bytes = { version = "1.0", optional = true }
+mac_address = { version = "1.1", features = ["serde"], optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
@@ -86,6 +87,10 @@ required-features = ["ui_test"]
 [[test]]
 name = "url"
 required-features = ["url"]
+
+[[test]]
+name = "mac_address"
+required-features = ["mac_address"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/mac_address.rs
+++ b/schemars/src/json_schema_impls/mac_address.rs
@@ -1,0 +1,29 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use mac_address::MacAddress;
+
+impl JsonSchema for MacAddress {
+    fn schema_name() -> String {
+        "MacAddress".to_string()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            metadata: Some(Box::new(Metadata {
+                description: Some("Contains the individual bytes of the MAC address.".to_string()),
+                examples: vec![serde_json::to_value(
+                    "aa:bb:cc:00:11:22".parse::<MacAddress>().unwrap(),
+                )]
+                .into_iter()
+                .flatten()
+                .collect(),
+                ..Default::default()
+            })),
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("mac_addr".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -50,6 +50,8 @@ mod either;
 mod ffi;
 #[cfg(feature = "indexmap")]
 mod indexmap;
+#[cfg(feature = "mac_address")]
+mod mac_address;
 mod maps;
 mod nonzero_signed;
 mod nonzero_unsigned;

--- a/schemars/tests/expected/mac_address.json
+++ b/schemars/tests/expected/mac_address.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MacAddress",
+  "description": "Contains the individual bytes of the MAC address.",
+  "examples": [
+    "AA:BB:CC:00:11:22"
+  ],
+  "type": "string",
+  "format": "mac_addr"
+}

--- a/schemars/tests/mac_address.rs
+++ b/schemars/tests/mac_address.rs
@@ -1,0 +1,8 @@
+mod util;
+use mac_address::MacAddress;
+use util::*;
+
+#[test]
+fn mac_address() -> TestResult {
+    test_default_generated_schema::<MacAddress>("mac_address")
+}


### PR DESCRIPTION
Adds a `JsonSchema` implementation for `MacAddress` from the [mac_address crate](https://crates.io/crates/mac_address).