### PR TITLE
Tagged enums as if else

### DIFF
--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -253,7 +253,7 @@ fn expr_for_internal_tagged_enum<'a>(
             ..Default::default()
         })),
         subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
-            any_of: Some(vec![#(#variant_schemas),*]),
+            all_of: Some(vec![#(#variant_schemas),*]),
             ..Default::default()
         })),
     })

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -193,41 +193,65 @@ fn expr_for_internal_tagged_enum<'a>(
     tag_name: &str,
     deny_unknown_fields: bool,
 ) -> TokenStream {
-    let variant_schemas = variants.map(|variant| {
+    let variants = variants.collect::<Vec<_>>();
+    let enum_values = variants
+        .iter()
+        .map(|variant| variant.name())
+        .collect::<Vec<_>>();
+    let variant_schemas = variants.iter().map(|variant| {
         let name = variant.name();
-        let type_schema = schema_object(quote! {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            enum_values: Some(vec![#name.into()]),
-        });
+        let doc_metadata = SchemaMetadata::from_attrs(&variant.attrs);
 
-        let tag_schema = schema_object(quote! {
-            instance_type: Some(schemars::schema::InstanceType::Object.into()),
+        let const_schema = schema_object(quote!(
+            const_value: Some(#name.into()),
+        ));
+
+        let if_schema = schema_object(quote! {
             object: Some(Box::new(schemars::schema::ObjectValidation {
                 properties: {
                     let mut props = schemars::Map::new();
-                    props.insert(#tag_name.to_owned(), #type_schema);
+                    props.insert(#tag_name.to_owned(), #const_schema);
                     props
-                },
-                required: {
-                    let mut required = schemars::Set::new();
-                    required.insert(#tag_name.to_owned());
-                    required
                 },
                 ..Default::default()
             })),
         });
-        let doc_metadata = SchemaMetadata::from_attrs(&variant.attrs);
-        let tag_schema = doc_metadata.apply_to_schema(tag_schema);
 
-        match expr_for_untagged_enum_variant_for_flatten(&variant, deny_unknown_fields) {
-            Some(variant_schema) => quote! {
-                #tag_schema.flatten(#variant_schema)
-            },
-            None => tag_schema,
-        }
+        let variant_schema =
+            expr_for_untagged_enum_variant_for_flatten(&variant, deny_unknown_fields)
+                .unwrap_or(quote! {schemars::schema::Schema::Bool(true)}); // TODO?
+
+        let variant_schema = schema_object(quote! {
+            subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
+                if_schema: Some(Box::new(#if_schema)),
+                then_schema: Some(Box::new(#variant_schema)),
+                ..Default::default()
+            })),
+        });
+        let variant_schema = doc_metadata.apply_to_schema(variant_schema);
+        variant_schema
+    });
+
+    let type_schema = schema_object(quote! {
+        instance_type: Some(schemars::schema::InstanceType::String.into()),
+        enum_values: Some(vec![#(#enum_values.into()),*]),
     });
 
     schema_object(quote! {
+        instance_type: Some(schemars::schema::InstanceType::Object.into()),
+        object: Some(Box::new(schemars::schema::ObjectValidation {
+            properties: {
+                let mut props = schemars::Map::new();
+                props.insert(#tag_name.to_owned(), #type_schema);
+                props
+            },
+            required: {
+                let mut required = schemars::Set::new();
+                required.insert(#tag_name.to_owned());
+                required
+            },
+            ..Default::default()
+        })),
         subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
             any_of: Some(vec![#(#variant_schemas),*]),
             ..Default::default()


### PR DESCRIPTION
Currently internally tagged enums are converted to an any_of of all possible variants and each of these variants gets a field for the tag with one possible value. For validation purposes, this might be fine. I was, however, using it in combination with https://github.com/redhat-developer/yaml-language-server and the results where not satisfactory.

Due to the fact that the tag field is added to each variant, the autocomplete could not show me all possible (enum) values for the tag field. In this PR, I changed the serialization of tagged enum to an object with a field for the tag and a subschema with an all_of. This all_of contains each variants, but only conditionally, where the condition is that the tag field equals the value for the specific enum. 

I did also see https://github.com/GREsau/schemars/pull/91 but that solution is not JsonSchema compatible.

I submit this as a draft because of two reasons:
- I am not sure that you like this behavior? I do personally think that is it better
- The tests are now failing, and I don't know where I should change the 'expected value' for the test
