### PR TITLE
Fixes for internally tagged enums and flattening additional_properties

### DIFF
--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -38,6 +38,31 @@ macro_rules! impl_merge {
     };
 }
 
+// For ObjectValidation::additional_properties.
+impl Merge for Option<Box<Schema>> {
+    fn merge(self, other: Self) -> Self {
+        match (self.map(|x| *x), other.map(|x| *x)) {
+            // Perfer permissive schemas.
+            (Some(Schema::Bool(true)), _) => Some(Box::new(true.into())),
+            (_, Some(Schema::Bool(true))) => Some(Box::new(true.into())),
+            (None, _) => None,
+            (_, None) => None,
+
+            // Merge if we have two non-trivial schemas.
+            (Some(Schema::Object(s1)), Some(Schema::Object(s2))) => {
+                Some(Box::new(Schema::Object(s1.merge(s2))))
+            }
+
+            // Perfer the more permissive schema.
+            (Some(s1 @ Schema::Object(_)), Some(Schema::Bool(false))) => Some(Box::new(s1)),
+            (Some(Schema::Bool(false)), Some(s2 @ Schema::Object(_))) => Some(Box::new(s2)),
+
+            // Default to the null schema.
+            (Some(Schema::Bool(false)), Some(Schema::Bool(false))) => Some(Box::new(false.into())),
+        }
+    }
+}
+
 impl_merge!(SchemaObject {
     merge: extensions instance_type enum_values
         metadata subschemas number string array object,
@@ -76,8 +101,8 @@ impl_merge!(ArrayValidation {
 });
 
 impl_merge!(ObjectValidation {
-    merge: required properties pattern_properties,
-    or: max_properties min_properties additional_properties property_names,
+    merge: required properties pattern_properties additional_properties,
+    or: max_properties min_properties property_names,
 });
 
 impl<T: Merge> Merge for Option<T> {

--- a/schemars/tests/enum.rs
+++ b/schemars/tests/enum.rs
@@ -99,3 +99,16 @@ pub enum Adjacent {
 fn enum_adjacent_tagged() -> TestResult {
     test_default_generated_schema::<Adjacent>("enum-adjacent-tagged")
 }
+
+#[derive(Debug, JsonSchema)]
+#[schemars(tag = "typeProperty")]
+pub enum SimpleInternal {
+    A,
+    B,
+    C,
+}
+
+#[test]
+fn enum_simple_internal_tag() -> TestResult {
+    test_default_generated_schema::<SimpleInternal>("enum-simple-internal")
+}

--- a/schemars/tests/enum_deny_unknown_fields.rs
+++ b/schemars/tests/enum_deny_unknown_fields.rs
@@ -104,3 +104,16 @@ pub enum Adjacent {
 fn enum_adjacent_tagged() -> TestResult {
     test_default_generated_schema::<Adjacent>("enum-adjacent-tagged-duf")
 }
+
+#[derive(Debug, JsonSchema)]
+#[schemars(tag = "typeProperty", deny_unknown_fields)]
+pub enum SimpleInternal {
+    A,
+    B,
+    C,
+}
+
+#[test]
+fn enum_simple_internal_tag() -> TestResult {
+    test_default_generated_schema::<SimpleInternal>("enum-simple-internal-duf")
+}

--- a/schemars/tests/expected/enum-internal-duf.json
+++ b/schemars/tests/expected/enum-internal-duf.json
@@ -14,7 +14,8 @@
             "UnitOne"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -45,7 +46,8 @@
             "UnitStructNewType"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": "object",
@@ -106,7 +108,8 @@
             "UnitTwo"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     {
       "type": [
@@ -124,7 +127,8 @@
             "WithInt"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/schemars/tests/expected/enum-internal.json
+++ b/schemars/tests/expected/enum-internal.json
@@ -28,9 +28,6 @@
             "StringMap"
           ]
         }
-      },
-      "additionalProperties": {
-        "type": "string"
       }
     },
     {

--- a/schemars/tests/expected/enum-simple-internal-duf.json
+++ b/schemars/tests/expected/enum-simple-internal-duf.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SimpleInternal",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "A"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "B"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "C"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/schemars/tests/expected/enum-simple-internal.json
+++ b/schemars/tests/expected/enum-simple-internal.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SimpleInternal",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "A"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "B"
+          ]
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "typeProperty"
+      ],
+      "properties": {
+        "typeProperty": {
+          "type": "string",
+          "enum": [
+            "C"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Flattening has some surprising outcomes when it comes to the `additional_properties` field. Consider that `None` is equivalent to `Some(Schema::Bool(true))`; merge currently prefers any `Some` to any `None` irrespective of the contents. Given the context of merge/flatten, the result of merging two `additional_field` values should be the union of the two schemas i.e. the schema that validates either.

This is particularly relevant for internally tagged schemas where currently additional properties are allowed even when `deny_unknown_fields` is set *and* can be constrained e.g. when a variant such as `StringMap(Map<&'static str, &'static str>),` is present.