### PR TITLE
Add examples attribute

### DIFF
--- a/docs/1.1-attributes.md
+++ b/docs/1.1-attributes.md
@@ -45,7 +45,7 @@ TABLE OF CONTENTS
 1. [Other Attributes](#other-attributes)
     - [`schema_with`](#schema_with)
     - [`title` / `description`](#title-description)
-    - [`example`](#example)
+    - [`example` / `examples`](#example)
     - [`deprecated`](#deprecated)
     - [`crate`](#crate)
     - [Doc Comments (`doc`)](#doc)
@@ -247,10 +247,12 @@ Set on a container, variant or field to set the generated schema's `title` and/o
 
 <h3 id="example">
 
-`#[schemars(example = "some::function")]`
+`#[schemars(example = "some::function", examples = "some::other::function")]`
 </h3>
 
-Set on a container, variant or field to include the result of the given function in the generated schema's `examples`. The function should take no parameters and can return any type that implements serde's `Serialize` trait - it does not need to return the same type as the attached struct/field. This attribute can be repeated to specify multiple examples.
+Set on a container, variant or field to include the result of the given function in the generated schema's `examples`. The function should take no parameters and can return any type that implements serde's `Serialize` trait, i.e. it must be callable as `fn() -> impl Serialize`. It does not need to return the same type as the attached struct/field. This attribute can be repeated to specify multiple examples.
+
+Alternatively, there is the `examples` attribute. It works the same as the `example` attribute but the function must have the signature `fn() -> impl IntoIterator<Item = impl Serialize>` instead. Each item the iterator yields is added as an example. Both attributes `example` and `examples` can be combined at will.
 
 <h3 id="deprecated">
 

--- a/schemars/tests/examples.rs
+++ b/schemars/tests/examples.rs
@@ -1,4 +1,6 @@
 mod util;
+use std::ops::Range;
+
 use schemars::JsonSchema;
 use serde::Serialize;
 use util::*;
@@ -22,4 +24,38 @@ fn null() -> () {}
 #[test]
 fn examples() -> TestResult {
     test_default_generated_schema::<Struct>("examples")
+}
+
+#[derive(Default, Debug, JsonSchema, Serialize)]
+#[schemars(example = "Struct::default", examples = "array")]
+pub struct StructExampleSet {
+    #[schemars(examples = "range", example = "null")]
+    foo: i32,
+    #[schemars(examples = "bar_values")]
+    bar: usize,
+    #[schemars(examples = "array")]
+    baz: Option<&'static str>,
+}
+
+fn range() -> Range<i32> {
+    1..20
+}
+
+fn array() -> [&'static str; 3] {
+    ["rust", "cpp", "c"]
+}
+
+fn bar_values() -> impl IntoIterator<Item = impl Serialize> {
+    let mut u = 0u8;
+    std::iter::from_fn(move || {
+        u.checked_add(60).map(|v| {
+            u = v;
+            v
+        })
+    })
+}
+
+#[test]
+fn example_sets() -> TestResult {
+    test_default_generated_schema::<StructExampleSet>("example_sets")
 }

--- a/schemars/tests/expected/example_sets.json
+++ b/schemars/tests/expected/example_sets.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StructExampleSet",
+  "examples": [
+    "rust",
+    "cpp",
+    "c",
+    {
+      "bar": false,
+      "baz": null,
+      "foo": 0
+    }
+  ],
+  "type": "object",
+  "required": [
+    "bar",
+    "foo"
+  ],
+  "properties": {
+    "bar": {
+      "examples": [
+        60,
+        120,
+        180,
+        240
+      ],
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "baz": {
+      "examples": [
+        "rust",
+        "cpp",
+        "c"
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "foo": {
+      "examples": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        null
+      ],
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -25,6 +25,7 @@ pub struct Attrs {
     pub description: Option<String>,
     pub deprecated: bool,
     pub examples: Vec<syn::Path>,
+    pub example_sets: Vec<syn::Path>,
     pub repr: Option<syn::Type>,
     pub crate_name: Option<syn::Path>,
 }
@@ -69,6 +70,7 @@ impl Attrs {
             description: self.description.as_ref().and_then(none_if_empty),
             deprecated: self.deprecated,
             examples: &self.examples,
+            example_sets: &self.example_sets,
             read_only: false,
             write_only: false,
             default: None,
@@ -149,6 +151,12 @@ impl Attrs {
                 Meta(NameValue(m)) if m.path.is_ident("example") => {
                     if let Ok(fun) = parse_lit_into_path(errors, attr_type, "example", &m.lit) {
                         self.examples.push(fun)
+                    }
+                }
+
+                Meta(NameValue(m)) if m.path.is_ident("examples") => {
+                    if let Ok(fun) = parse_lit_into_path(errors, attr_type, "examples", &m.lit) {
+                        self.example_sets.push(fun)
                     }
                 }
 


### PR DESCRIPTION
I added a small feature:
I tried to add multiple examples to a single struct field but found it quite cumbersome. I had to create a new function for every example values I wanted to add.

Therefore I implemented an attribute `examples` that works just like `example`. But instead of providing a single example value, the user can provide anything implementing `IntoIterator` to return an arbitrary number of examples from a single function.

Example:
```rust
#[derive(JsonSchema, Deserialize)]
struct Config {
    #[schemars(examples = "revisions")]
    git_revision: String,
}

fn revisions() -> [&'static str; 3] {
    ["master", "v0.3.0", "5dfcdf8eec66a051ecd85625518cfd13"]
}
```

This was my first time writing `proc-macros` so please look out for errors when reviewing (e.g. macro hygiene?).