### PR TITLE
Add example for optional dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,10 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - [`url`](https://crates.io/crates/url) (^2.0)
 - [`bytes`](https://crates.io/crates/bytes) (^1.0)
 - [`enumset`](https://crates.io/crates/enumset) (^1.0)
+
+As an example, to enable `JsonSchema` types for the `chrono` crate, load `schemars` like this in your `cargo.toml`:
+
+```toml
+[dependencies]
+schemars = { version = "0.8", features = ["chrono"] }
+```


### PR DESCRIPTION
Thanks for `schemars`! It took me a while to figure out how to enable optional dependencies. Fortunately, https://graham.cool/schemars/features provides an example. This pull request makes this example better discoverable by adding it to the main readme file.