### PR TITLE
Adds `ipnet` optional feature with JsonSchema for it.

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -29,6 +29,7 @@ bytes = { version = "1.0", optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 enumset = { version = "1.0", optional = true }
+ipnet = { version = "2.3.1", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
@@ -93,6 +94,10 @@ required-features = ["url"]
 [[test]]
 name = "enumset"
 required-features = ["enumset"]
+
+[[test]]
+name = "ipnet"
+required-features = ["ipnet"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/ipnet.rs
+++ b/schemars/src/json_schema_impls/ipnet.rs
@@ -1,0 +1,55 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+
+impl JsonSchema for IpNet {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "IpNet".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("ipnet".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl JsonSchema for Ipv4Net {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "Ipv4Net".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("ipv4net".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl JsonSchema for Ipv6Net {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "Ipv6Net".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("ipv6net".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -69,3 +69,5 @@ mod url;
 #[cfg(feature = "uuid")]
 mod uuid;
 mod wrapper;
+#[cfg(feature = "ipnet")]
+mod ipnet;

--- a/schemars/tests/expected/ipnet.json
+++ b/schemars/tests/expected/ipnet.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IpNetTypes",
+  "type": "object",
+  "required": [
+    "ipnet",
+    "ipv4net",
+    "ipv6net"
+  ],
+  "properties": {
+    "ipnet": {
+      "type": "string",
+      "format": "ipnet"
+    },
+    "ipv4net": {
+      "type": "string",
+      "format": "ipv4net"
+    },
+    "ipv6net": {
+      "type": "string",
+      "format": "ipv6net"
+    }
+  }
+}

--- a/schemars/tests/ipnet.rs
+++ b/schemars/tests/ipnet.rs
@@ -1,0 +1,17 @@
+mod util;
+use schemars::JsonSchema;
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use util::*;
+
+#[derive(Debug, JsonSchema)]
+struct IpNetTypes {
+    ipnet: IpNet,
+    ipv4net: Ipv4Net,
+    ipv6net: Ipv6Net,
+}
+
+#[test]
+fn url_types() -> TestResult {
+    test_default_generated_schema::<IpNetTypes>("ipnet")
+}
+


### PR DESCRIPTION
IpNet is a commonly used crate for IP addresses with prefix (eg. `10.0.0.1/16`). There is a [merge request](https://github.com/krisprice/ipnet/pull/31) open on the repo, but looks like it hasn't been accepted in a 6 months. Can we add this to schemars instead?