### PR TITLE
Add basic support for enum variant aliases

### DIFF
--- a/schemars/tests/enum.rs
+++ b/schemars/tests/enum.rs
@@ -112,3 +112,15 @@ pub enum SimpleInternal {
 fn enum_simple_internal_tag() -> TestResult {
     test_default_generated_schema::<SimpleInternal>("enum-simple-internal")
 }
+
+#[derive(Debug, JsonSchema)]
+pub enum Aliased {
+    #[schemars(alias = "v1", alias = "variant1")]
+    V1,
+    #[schemars(alias = "v2", alias = "variant2")]
+    V2,
+}
+#[test]
+fn enum_aliased() -> TestResult {
+    test_default_generated_schema::<Aliased>("enum-aliased")
+}

--- a/schemars/tests/expected/enum-aliased.json
+++ b/schemars/tests/expected/enum-aliased.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Aliased",
+  "type": "string",
+  "enum": [
+    "v1",
+    "variant1",
+    "V1",
+    "v2",
+    "variant2",
+    "V2"
+  ]
+}

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -27,6 +27,7 @@ pub struct Attrs {
     pub examples: Vec<syn::Path>,
     pub repr: Option<syn::Type>,
     pub crate_name: Option<syn::Path>,
+    pub aliases: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -159,6 +160,12 @@ impl Attrs {
                         } else {
                             self.crate_name = Some(p)
                         }
+                    }
+                }
+
+                Meta(NameValue(m)) if m.path.is_ident("alias") && attr_type == "serde" => {
+                    if let Ok(alias) = get_lit_str(errors, attr_type, "alias", &m.lit) {
+                        self.aliases.push(alias.value())
                     }
                 }
 

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -6,6 +6,7 @@ use syn::{Attribute, Data, Field, Meta, NestedMeta, Variant};
 
 // List of keywords that can appear in #[serde(...)]/#[schemars(...)] attributes which we want serde_derive_internals to parse for us.
 pub(crate) static SERDE_KEYWORDS: &[&str] = &[
+    "alias",
     "rename",
     "rename_all",
     "deny_unknown_fields",

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -151,7 +151,12 @@ fn expr_for_external_tagged_enum<'a>(
         })
         .partition(|v| v.is_unit() && v.attrs.with.is_none());
 
-    let unit_names = unit_variants.iter().map(|v| v.name());
+    let unit_names = unit_variants.iter().map(|v| {
+        let mut names: Vec<String> = Vec::with_capacity(1 + v.attrs.aliases.len());
+        names.extend_from_slice(&v.attrs.aliases);
+        names.push(v.name());
+        names
+    }).flatten();
     let unit_schema = schema_object(quote! {
         instance_type: Some(schemars::schema::InstanceType::String.into()),
         enum_values: Some(vec![#(#unit_names.into()),*]),
@@ -188,7 +193,7 @@ fn expr_for_external_tagged_enum<'a>(
                 // `deny_unknown_fields`. If additional properties were allowed
                 // one could easily construct an object that validated against
                 // multiple variants since here it's the properties rather than
-                // the values of a property that distingish between variants.
+                // the values of a property that distinguish between variants.
                 additional_properties: Some(Box::new(false.into())),
                 ..Default::default()
             })),


### PR DESCRIPTION
Hi! This is a fairly basic implementation to have `#[serde(alias = "foo")]` result in additional enum variants in the generated schema. I would be happy to make this configurable via `GeneratorSettings`, extend it to the other possible enum representations and add more tests. I just wanted to check first with you if there is some fundamental flaw with this feature or if my implementation is totally backwards.

Thank you for this great project!

Unrelated P.S.: Would you be interested in the following 2 post-processing visitors I implemented to make my schema work for my use case?
```rust
/// Removes any generated "format" keys in the generated schema
///
/// Schemars will add "format" entries like e.g. "uint64".
/// This isn't even known in the OpenAPI 3 spec and much less for vanilla json-schema.
struct RemoveTypeFormats;

/// Removes `"additionalProperties": false` from any structs which have an "oneOf"
///
/// At least [jsonschemalint.com](https://jsonschemalint.com/) does not allow properties not listed in `properties` to be "consumed" by `one_of` instead.
struct RemoveAdditionalPropsFalseWhereEnumFlattened;
```