### PR TITLE
Bump dependencies

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -14,25 +14,25 @@ build = "build.rs"
 
 [dependencies]
 schemars_derive = { version = "=0.8.8", optional = true, path = "../schemars_derive" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dyn-clone = "1.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
+dyn-clone = "1.0.5"
 
-chrono = { version = "0.4", default-features = false, optional = true }
-indexmap = { version = "1.2", features=["serde-1"], optional = true }
-either = { version = "1.3", default-features = false, optional = true }
-uuid = { version = "0.8", default-features = false, optional = true }
-smallvec = { version = "1.0", optional = true }
-arrayvec = { version = "0.5", default-features = false, optional = true }
-url = { version = "2.0", default-features = false, optional = true }
-bytes = { version = "1.0", optional = true }
-rust_decimal = { version = "1", default-features = false, optional = true }
-bigdecimal = { version = "0.3", default-features = false, optional = true }
-enumset = { version = "1.0", optional = true }
+chrono = { version = "0.4.19", default-features = false, optional = true }
+indexmap = { version = "1.6.2", features = ["serde-1"], optional = true }
+either = { version = "1.6.1", default-features = false, optional = true }
+uuid = { version = "1.0.0", default-features = false, optional = true }
+smallvec = { version = "1.8.0", optional = true }
+arrayvec = { version = "0.7.2", default-features = false, optional = true }
+url = { version = "2.2.2", default-features = false, optional = true }
+bytes = { version = "1.1.0", optional = true }
+rust_decimal = { version = "1.23.1", default-features = false, optional = true }
+bigdecimal = { version = "0.3.0", default-features = false, optional = true }
+enumset = { version = "1.0.11", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
-trybuild = "1.0"
+pretty_assertions = "1.2.1"
+trybuild = "1.0.60"
 
 [features]
 default = ["derive"]

--- a/schemars/src/json_schema_impls/arrayvec.rs
+++ b/schemars/src/json_schema_impls/arrayvec.rs
@@ -1,33 +1,29 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
-use arrayvec::{Array, ArrayString, ArrayVec};
+use arrayvec::{ArrayString, ArrayVec};
 use std::convert::TryInto;
 
 // Do not set maxLength on the schema as that describes length in characters, but we only
 // know max length in bytes.
-forward_impl!((<A> JsonSchema for ArrayString<A> where A: Array<Item = u8> + Copy) => String);
+forward_impl!((<const CAP: usize> JsonSchema for ArrayString<CAP>) => String);
 
-impl<A: Array> JsonSchema for ArrayVec<A>
+impl<T, const CAP: usize> JsonSchema for ArrayVec<T, CAP>
 where
-    A::Item: JsonSchema,
+    T: JsonSchema,
 {
     no_ref_schema!();
 
     fn schema_name() -> String {
-        format!(
-            "Array_up_to_size_{}_of_{}",
-            A::CAPACITY,
-            A::Item::schema_name()
-        )
+        format!("Array_up_to_size_{}_of_{}", CAP, T::schema_name())
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
         SchemaObject {
             instance_type: Some(InstanceType::Array.into()),
             array: Some(Box::new(ArrayValidation {
-                items: Some(gen.subschema_for::<A::Item>().into()),
-                max_items: A::CAPACITY.try_into().ok(),
+                items: Some(gen.subschema_for::<T>().into()),
+                max_items: CAP.try_into().ok(),
                 ..Default::default()
             })),
             ..Default::default()

--- a/schemars/tests/arrayvec.rs
+++ b/schemars/tests/arrayvec.rs
@@ -4,10 +4,10 @@ use util::*;
 
 #[test]
 fn arrayvec() -> TestResult {
-    test_default_generated_schema::<ArrayVec<[i32; 16]>>("arrayvec")
+    test_default_generated_schema::<ArrayVec<i32, 16>>("arrayvec")
 }
 
 #[test]
 fn arrayvec_string() -> TestResult {
-    test_default_generated_schema::<ArrayString<[u8; 16]>>("arrayvec_string")
+    test_default_generated_schema::<ArrayString<16>>("arrayvec_string")
 }

--- a/schemars_derive/Cargo.toml
+++ b/schemars_derive/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["rust", "json-schema", "serde"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
-serde_derive_internals = "0.25"
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+syn = { version = "1.0.91", features = ["extra-traits"] }
+serde_derive_internals = "0.26.0"
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
+pretty_assertions = "1.2.1"


### PR DESCRIPTION
* `uuid` 0.8 -> 1.0
* `arrayvec` 0.5 -> 0.7
* `pretty_assertions` 0.6.1 -> 1.2.1
* `serde_derive_internals` 0.25 -> 0.26

Also the maintainers may wish to consider this post about specifying precise dependency versions https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277, if they agree I can quickly make those changes as part of this PR.