### PR TITLE
Support for ordered-float crate

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -31,6 +31,7 @@ bytes = { version = "1.0", optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 enumset = { version = "1.0", optional = true }
+ordered-float = { version = "3.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -72,4 +72,6 @@ mod url;
 mod uuid08;
 #[cfg(feature = "uuid1")]
 mod uuid1;
+#[cfg(feature = "ordered-float")]
+mod ordered_float;
 mod wrapper;

--- a/schemars/src/json_schema_impls/ordered_float.rs
+++ b/schemars/src/json_schema_impls/ordered_float.rs
@@ -1,0 +1,38 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use ordered_float::OrderedFloat;
+
+impl JsonSchema for OrderedFloat<f32> {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "float".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::Number.into()),
+            format: Some("float".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl JsonSchema for OrderedFloat<f64> {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "double".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::Number.into()),
+            format: Some("double".to_owned()),
+            ..Default::default()
+        }
+        .into()
+    }
+}


### PR DESCRIPTION
Adds a new feature/optional dependencies for the ordered-float crate and
implements JsonSchema for `OrderedFloat<f32>` and `OrderedFloat<f64>`.
