### PR TITLE
Fix some lints as suggest by clippy

### DIFF
--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -257,7 +257,7 @@ impl From<Schema> for SchemaObject {
 }
 
 /// Properties which annotate a [`SchemaObject`] which typically have no effect when an object is being validated against the schema.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 pub struct Metadata {
@@ -386,7 +386,7 @@ pub struct NumberValidation {
 }
 
 /// Properties of a [`SchemaObject`] which define validation assertions for strings.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 pub struct StringValidation {

--- a/schemars/src/ser.rs
+++ b/schemars/src/ser.rs
@@ -128,7 +128,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         self.serialize_none()
     }
 
-    fn serialize_some<T: ?Sized>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
@@ -153,7 +153,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         if self.gen.settings().option_add_null_type {
             schema = match schema {
                 Schema::Bool(true) => Schema::Bool(true),
-                Schema::Bool(false) => <()>::json_schema(&mut self.gen),
+                Schema::Bool(false) => <()>::json_schema(self.gen),
                 Schema::Object(SchemaObject {
                     instance_type: Some(ref mut instance_type),
                     ..
@@ -163,7 +163,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
                 }
                 schema => SchemaObject {
                     subschemas: Some(Box::new(SubschemaValidation {
-                        any_of: Some(vec![schema, <()>::json_schema(&mut self.gen)]),
+                        any_of: Some(vec![schema, <()>::json_schema(self.gen)]),
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -44,14 +44,14 @@ pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), Vec<syn::
 
 fn process_serde_variant_attrs<'a>(ctxt: &Ctxt, variants: impl Iterator<Item = &'a mut Variant>) {
     for v in variants {
-        process_attrs(&ctxt, &mut v.attrs);
-        process_serde_field_attrs(&ctxt, v.fields.iter_mut());
+        process_attrs(ctxt, &mut v.attrs);
+        process_serde_field_attrs(ctxt, v.fields.iter_mut());
     }
 }
 
 fn process_serde_field_attrs<'a>(ctxt: &Ctxt, fields: impl Iterator<Item = &'a mut Field>) {
     for f in fields {
-        process_attrs(&ctxt, &mut f.attrs);
+        process_attrs(ctxt, &mut f.attrs);
     }
 }
 
@@ -68,10 +68,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
 
     let (mut serde_meta, mut schemars_meta_names): (Vec<_>, HashSet<_>) = schemars_attrs
         .iter()
-        .flat_map(|at| get_meta_items(&ctxt, at))
+        .flat_map(|at| get_meta_items(ctxt, at))
         .flatten()
         .filter_map(|meta| {
-            let keyword = get_meta_ident(&ctxt, &meta).ok()?;
+            let keyword = get_meta_ident(ctxt, &meta).ok()?;
             if keyword.ends_with("with") || !SERDE_KEYWORDS.contains(&keyword.as_ref()) {
                 None
             } else {
@@ -87,10 +87,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
 
     for meta in serde_attrs
         .into_iter()
-        .flat_map(|at| get_meta_items(&ctxt, &at))
+        .flat_map(|at| get_meta_items(ctxt, &at))
         .flatten()
     {
-        if let Ok(i) = get_meta_ident(&ctxt, &meta) {
+        if let Ok(i) = get_meta_ident(ctxt, &meta) {
             if !schemars_meta_names.contains(&i) && SERDE_KEYWORDS.contains(&i.as_ref()) {
                 serde_meta.push(meta);
             }

--- a/schemars_derive/src/attr/validation.rs
+++ b/schemars_derive/src/attr/validation.rs
@@ -7,7 +7,7 @@ pub(crate) static VALIDATION_KEYWORDS: &[&str] = &[
     "range", "regex", "contains", "email", "phone", "url", "length", "required",
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Format {
     Email,
     Uri,
@@ -112,7 +112,7 @@ impl ValidationAttrs {
                                 } else if self.length_equal.is_some() {
                                     mutual_exclusive_error(&nv.path, "equal")
                                 } else {
-                                    self.length_min = str_or_num_to_expr(&errors, "min", &nv.lit);
+                                    self.length_min = str_or_num_to_expr(errors, "min", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("max") => {
@@ -121,7 +121,7 @@ impl ValidationAttrs {
                                 } else if self.length_equal.is_some() {
                                     mutual_exclusive_error(&nv.path, "equal")
                                 } else {
-                                    self.length_max = str_or_num_to_expr(&errors, "max", &nv.lit);
+                                    self.length_max = str_or_num_to_expr(errors, "max", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("equal") => {
@@ -133,14 +133,14 @@ impl ValidationAttrs {
                                     mutual_exclusive_error(&nv.path, "max")
                                 } else {
                                     self.length_equal =
-                                        str_or_num_to_expr(&errors, "equal", &nv.lit);
+                                        str_or_num_to_expr(errors, "equal", &nv.lit);
                                 }
                             }
                             meta => {
                                 if !ignore_errors {
                                     errors.error_spanned_by(
                                         meta,
-                                        format!("unknown item in schemars length attribute"),
+                                        "unknown item in schemars length attribute".to_string(),
                                     );
                                 }
                             }
@@ -155,21 +155,21 @@ impl ValidationAttrs {
                                 if self.range_min.is_some() {
                                     duplicate_error(&nv.path)
                                 } else {
-                                    self.range_min = str_or_num_to_expr(&errors, "min", &nv.lit);
+                                    self.range_min = str_or_num_to_expr(errors, "min", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("max") => {
                                 if self.range_max.is_some() {
                                     duplicate_error(&nv.path)
                                 } else {
-                                    self.range_max = str_or_num_to_expr(&errors, "max", &nv.lit);
+                                    self.range_max = str_or_num_to_expr(errors, "max", &nv.lit);
                                 }
                             }
                             meta => {
                                 if !ignore_errors {
                                     errors.error_spanned_by(
                                         meta,
-                                        format!("unknown item in schemars range attribute"),
+                                        "unknown item in schemars range attribute".to_string(),
                                     );
                                 }
                             }
@@ -247,7 +247,8 @@ impl ValidationAttrs {
                                         if !ignore_errors {
                                             errors.error_spanned_by(
                                                 meta,
-                                                format!("unknown item in schemars regex attribute"),
+                                                "unknown item in schemars regex attribute"
+                                                    .to_string(),
                                             );
                                         }
                                     }
@@ -261,8 +262,8 @@ impl ValidationAttrs {
                     if path.is_ident("contains") =>
                 {
                     match (&self.contains, &self.regex) {
-                        (Some(_), _) => duplicate_error(&path),
-                        (None, Some(_)) => mutual_exclusive_error(&path, "regex"),
+                        (Some(_), _) => duplicate_error(path),
+                        (None, Some(_)) => mutual_exclusive_error(path, "regex"),
                         (None, None) => {
                             self.contains = get_lit_str(errors, attr_type, "contains", lit)
                                 .map(|litstr| litstr.value())
@@ -292,9 +293,8 @@ impl ValidationAttrs {
                                         if !ignore_errors {
                                             errors.error_spanned_by(
                                                 meta,
-                                                format!(
-                                                    "unknown item in schemars contains attribute"
-                                                ),
+                                                "unknown item in schemars contains attribute"
+                                                    .to_string(),
                                             );
                                         }
                                     }
@@ -316,11 +316,7 @@ impl ValidationAttrs {
         let mut object_validation = Vec::new();
         let mut string_validation = Vec::new();
 
-        if let Some(length_min) = self
-            .length_min
-            .as_ref()
-            .or_else(|| self.length_equal.as_ref())
-        {
+        if let Some(length_min) = self.length_min.as_ref().or(self.length_equal.as_ref()) {
             string_validation.push(quote! {
                 validation.min_length = Some(#length_min as u32);
             });
@@ -329,11 +325,7 @@ impl ValidationAttrs {
             });
         }
 
-        if let Some(length_max) = self
-            .length_max
-            .as_ref()
-            .or_else(|| self.length_equal.as_ref())
-        {
+        if let Some(length_max) = self.length_max.as_ref().or(self.length_equal.as_ref()) {
             string_validation.push(quote! {
                 validation.max_length = Some(#length_max as u32);
             });


### PR DESCRIPTION
These are some of the more useful lints fixed as suggest by clippy on nightly. I didn't fix them all as some of them are a bit sketchy.

@GREsau you might still want to look at the other suggested lints and either `#[allow()]` them or otherwise fix them.