### PR TITLE
Make schemars_derive add the Rust namespace to the schema_names.

### DIFF
--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -130,7 +130,7 @@ fn derive_json_schema(
             #[allow(unused_braces)]
             impl #impl_generics schemars::JsonSchema for #type_name #ty_generics #where_clause {
                 fn schema_name() -> std::string::String {
-                    #schema_name
+                    format!("{}::{}", module_path!(), #schema_name)
                 }
 
                 fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {


### PR DESCRIPTION
Right now, `#[derive(JsonSchema)]` does not include any namespace, even when deriving from Rust source files in different modules.

This can cause naming conflicts that are hard to debug (because one of the structs is made to stand in for the other same-named completely different struct in another module) and generally seem like a bad idea.

This PR is the easiest fix: It just prefixes the schema_name with the module_path. That way, the schema names are unique.
