### PR TITLE
Fix handling of attributes applied to unit variant types

### DIFF
--- a/schemars/tests/docs.rs
+++ b/schemars/tests/docs.rs
@@ -31,6 +31,7 @@ struct MyUnitStruct;
 #[doc = " the enum's description."]
 enum MyEnum {
     UndocumentedUnit,
+    UndocumentedUnit2,
     /// This comment is included in the generated schema :)
     DocumentedUnit,
     /// ## Complex variant

--- a/schemars/tests/docs.rs
+++ b/schemars/tests/docs.rs
@@ -31,7 +31,7 @@ struct MyUnitStruct;
 #[doc = " the enum's description."]
 enum MyEnum {
     UndocumentedUnit,
-    /// This comment is not included in the generated schema :(
+    /// This comment is included in the generated schema :)
     DocumentedUnit,
     /// ## Complex variant
     /// This is a struct-like variant.

--- a/schemars/tests/enum.rs
+++ b/schemars/tests/enum.rs
@@ -118,3 +118,21 @@ enum SimpleInternal {
 fn enum_simple_internal_tag() -> TestResult {
     test_default_generated_schema::<SimpleInternal>("enum-simple-internal")
 }
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum SoundOfMusic {
+    /// # A deer
+    ///
+    /// A female deer
+    Do,
+    /// A drop of golden sun
+    Re,
+    /// A name I call myself
+    Mi,
+}
+
+#[test]
+fn enum_unit_with_doc_comments() -> TestResult {
+    test_default_generated_schema::<SoundOfMusic>("enum-unit-doc")
+}

--- a/schemars/tests/expected/deprecated-enum.json
+++ b/schemars/tests/expected/deprecated-enum.json
@@ -6,7 +6,13 @@
     {
       "type": "string",
       "enum": [
-        "Unit",
+        "Unit"
+      ]
+    },
+    {
+      "deprecated": true,
+      "type": "string",
+      "enum": [
         "DeprecatedUnitVariant"
       ]
     },

--- a/schemars/tests/expected/doc_comments_enum.json
+++ b/schemars/tests/expected/doc_comments_enum.json
@@ -6,7 +6,13 @@
     {
       "type": "string",
       "enum": [
-        "UndocumentedUnit",
+        "UndocumentedUnit"
+      ]
+    },
+    {
+      "description": "This comment is included in the generated schema :)",
+      "type": "string",
+      "enum": [
         "DocumentedUnit"
       ]
     },

--- a/schemars/tests/expected/doc_comments_enum.json
+++ b/schemars/tests/expected/doc_comments_enum.json
@@ -6,7 +6,8 @@
     {
       "type": "string",
       "enum": [
-        "UndocumentedUnit"
+        "UndocumentedUnit",
+        "UndocumentedUnit2"
       ]
     },
     {

--- a/schemars/tests/expected/enum-unit-doc.json
+++ b/schemars/tests/expected/enum-unit-doc.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SoundOfMusic",
+  "oneOf": [
+    {
+      "title": "A deer",
+      "description": "A female deer",
+      "type": "string",
+      "enum": [
+        "Do"
+      ]
+    },
+    {
+      "description": "A drop of golden sun",
+      "type": "string",
+      "enum": [
+        "Re"
+      ]
+    },
+    {
+      "description": "A name I call myself",
+      "type": "string",
+      "enum": [
+        "Mi"
+      ]
+    }
+  ]
+}

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -185,6 +185,21 @@ impl Attrs {
         }
         self
     }
+
+    pub fn is_default(&self) -> bool {
+        match self {
+            Self {
+                with: None,
+                title: None,
+                description: None,
+                deprecated: false,
+                examples,
+                repr: None,
+                crate_name: None,
+            } if examples.is_empty() => true,
+            _ => false,
+        }
+    }
 }
 
 fn is_known_serde_or_validation_keyword(meta: &syn::Meta) -> bool {


### PR DESCRIPTION
Fixes #151 

Attributes applied to unit variants are not obeyed. In particular this was evident with `doc` and `deprecated` attributes which were simply ignored.