### PR TITLE
Implement JsonSchema for serde_yaml primitives as optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `enumset` - [enumset](https://crates.io/crates/enumset) (^1.0)
 - `rust_decimal` - [rust_decimal](https://crates.io/crates/rust_decimal) (^1.0)
 - `bigdecimal` - [bigdecimal](https://crates.io/crates/bigdecimal) (^0.3)
+- `serde_yaml` - [serde_yaml](https://crates.io/crates/serde_yaml) (^0.8)
 
 For example, to implement `JsonSchema` on types from `chrono`, enable it as a feature in the `schemars` dependency in your `Cargo.toml` like so:
 

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -31,6 +31,7 @@ bytes = { version = "1.0", optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 enumset = { version = "1.0", optional = true }
+serde_yaml = { version = "0.8", default-features = false, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -62,6 +62,8 @@ mod nonzero_unsigned;
 mod primitives;
 mod sequences;
 mod serdejson;
+#[cfg(feature = "serde_yaml")]
+mod serdeyaml;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 mod time;

--- a/schemars/src/json_schema_impls/serdeyaml.rs
+++ b/schemars/src/json_schema_impls/serdeyaml.rs
@@ -1,0 +1,35 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::{JsonSchema, Schema};
+use serde_yaml::{Mapping, Number, Value};
+use std::collections::BTreeMap;
+
+impl JsonSchema for Value {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "AnyValue".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        Schema::Bool(true)
+    }
+}
+
+forward_impl!(Mapping => BTreeMap<Value, Value>);
+
+impl JsonSchema for Number {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "Number".to_owned()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::Number.into()),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -280,8 +280,6 @@ For example, to implement `JsonSchema` on types from `chrono`, enable it as a fe
 [dependencies]
 schemars = { version = "0.8", features = ["chrono"] }
 ```
-
-```
 */
 
 /// The map type used by schemars types.

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -273,6 +273,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `enumset` - [enumset](https://crates.io/crates/enumset) (^1.0)
 - `rust_decimal` - [rust_decimal](https://crates.io/crates/rust_decimal) (^1.0)
 - `bigdecimal` - [bigdecimal](https://crates.io/crates/bigdecimal) (^0.3)
+- `serde_yaml` - [serde_yaml](https://crates.io/crates/serde_yaml) (^0.8)
 
 For example, to implement `JsonSchema` on types from `chrono`, enable it as a feature in the `schemars` dependency in your `Cargo.toml` like so:
 


### PR DESCRIPTION
Since yaml is a superset of json, some people (like me) may wish to expose their API over a yaml based serialization layer.
Those people may still wish to document their API using a *JsonSchema* which this PR enables by implementing the `JsonSchema` trait on [serde_yaml primitives](https://docs.rs/serde_yaml/latest/serde_yaml/enum.Value.html) similar to how they are [implemented for serde_json](https://github.com/GREsau/schemars/blob/master/schemars/src/json_schema_impls/serdejson.rs).

However, since not all people use yaml it is only implemented as an optional feature.