### PR TITLE
Allow specifying custom type bounds for derived `JsonSchema` instances

### DIFF
--- a/schemars/src/ser.rs
+++ b/schemars/src/ser.rs
@@ -128,7 +128,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         self.serialize_none()
     }
 
-    fn serialize_some<T: ?Sized>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
@@ -153,7 +153,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         if self.gen.settings().option_add_null_type {
             schema = match schema {
                 Schema::Bool(true) => Schema::Bool(true),
-                Schema::Bool(false) => <()>::json_schema(&mut self.gen),
+                Schema::Bool(false) => <()>::json_schema(self.gen),
                 Schema::Object(SchemaObject {
                     instance_type: Some(ref mut instance_type),
                     ..
@@ -163,7 +163,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
                 }
                 schema => SchemaObject {
                     subschemas: Some(Box::new(SubschemaValidation {
-                        any_of: Some(vec![schema, <()>::json_schema(&mut self.gen)]),
+                        any_of: Some(vec![schema, <()>::json_schema(self.gen)]),
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/schemars/tests/examples.rs
+++ b/schemars/tests/examples.rs
@@ -17,7 +17,7 @@ fn eight() -> i32 {
     8
 }
 
-fn null() -> () {}
+fn null() {}
 
 #[test]
 fn examples() -> TestResult {

--- a/schemars/tests/validate.rs
+++ b/schemars/tests/validate.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use util::*;
 
 // In real code, this would typically be a Regex, potentially created in a `lazy_static!`.
-static STARTS_WITH_HELLO: &'static str = r"^[Hh]ello\b";
+static STARTS_WITH_HELLO: &str = r"^[Hh]ello\b";
 
 const MIN: u32 = 1;
 const MAX: u32 = 1000;

--- a/schemars_derive/src/ast/from_serde.rs
+++ b/schemars_derive/src/ast/from_serde.rs
@@ -25,7 +25,7 @@ impl<'a> FromSerde for Container<'a> {
             ident: serde.ident,
             serde_attrs: serde.attrs,
             data: Data::from_serde(errors, serde.data)?,
-            generics: serde.generics,
+            generics: serde.generics.clone(),
             original: serde.original,
             // FIXME this allows with/schema_with attribute on containers
             attrs: Attrs::new(&serde.original.attrs, errors),

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -9,7 +9,7 @@ pub struct Container<'a> {
     pub ident: syn::Ident,
     pub serde_attrs: serde_derive_internals::attr::Container,
     pub data: Data<'a>,
-    pub generics: &'a syn::Generics,
+    pub generics: syn::Generics,
     pub original: &'a syn::DeriveInput,
     pub attrs: Attrs,
 }

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -30,6 +30,7 @@ pub struct Attrs {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum WithAttr {
     Type(syn::Type),
     Function(syn::Path),

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -51,14 +51,14 @@ pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), Vec<syn::
 
 fn process_serde_variant_attrs<'a>(ctxt: &Ctxt, variants: impl Iterator<Item = &'a mut Variant>) {
     for v in variants {
-        process_attrs(&ctxt, &mut v.attrs);
-        process_serde_field_attrs(&ctxt, v.fields.iter_mut());
+        process_attrs(ctxt, &mut v.attrs);
+        process_serde_field_attrs(ctxt, v.fields.iter_mut());
     }
 }
 
 fn process_serde_field_attrs<'a>(ctxt: &Ctxt, fields: impl Iterator<Item = &'a mut Field>) {
     for f in fields {
-        process_attrs(&ctxt, &mut f.attrs);
+        process_attrs(ctxt, &mut f.attrs);
     }
 }
 
@@ -75,10 +75,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
 
     let (mut serde_meta, mut schemars_meta_names): (Vec<_>, HashSet<_>) = schemars_attrs
         .iter()
-        .flat_map(|at| get_meta_items(&ctxt, at))
+        .flat_map(|at| get_meta_items(ctxt, at))
         .flatten()
         .filter_map(|meta| {
-            let keyword = get_meta_ident(&ctxt, &meta).ok()?;
+            let keyword = get_meta_ident(ctxt, &meta).ok()?;
             if keyword.ends_with("with") || !SERDE_KEYWORDS.contains(&keyword.as_ref()) {
                 None
             } else {
@@ -94,10 +94,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
 
     for meta in serde_attrs
         .into_iter()
-        .flat_map(|at| get_meta_items(&ctxt, &at))
+        .flat_map(|at| get_meta_items(ctxt, &at))
         .flatten()
     {
-        if let Ok(i) = get_meta_ident(&ctxt, &meta) {
+        if let Ok(i) = get_meta_ident(ctxt, &meta) {
             if !schemars_meta_names.contains(&i)
                 && SERDE_KEYWORDS.contains(&i.as_ref())
                 && !SERDE_UNINHERITED_KEYWORDS.contains(&i.as_ref())

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -20,6 +20,7 @@ pub(crate) static SERDE_KEYWORDS: &[&str] = &[
     "flatten",
     "remote",
     "transparent",
+    "bound",
     // Special cases - `with`/`serialize_with` are passed to serde but not copied from schemars attrs to serde attrs.
     // This is because we want to preserve any serde attribute's `serialize_with` value to determine whether the field's
     // default value should be serialized. We also check the `with` value on schemars/serde attrs e.g. to support deriving

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -29,6 +29,12 @@ pub(crate) static SERDE_KEYWORDS: &[&str] = &[
     "with",
 ];
 
+// List of keywords that we do not want to inherit from #[serde(...)] (but do want to serde to parse from #[schemars(...)])
+static SERDE_UNINHERITED_KEYWORDS: &[&str] = &[
+    // Used to be ignored completely by schemars
+    "bound",
+];
+
 // If a struct/variant/field has any #[schemars] attributes, then create copies of them
 // as #[serde] attributes so that serde_derive_internals will parse them for us.
 pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), Vec<syn::Error>> {
@@ -92,7 +98,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
         .flatten()
     {
         if let Ok(i) = get_meta_ident(&ctxt, &meta) {
-            if !schemars_meta_names.contains(&i) && SERDE_KEYWORDS.contains(&i.as_ref()) {
+            if !schemars_meta_names.contains(&i)
+                && SERDE_KEYWORDS.contains(&i.as_ref())
+                && !SERDE_UNINHERITED_KEYWORDS.contains(&i.as_ref())
+            {
                 serde_meta.push(meta);
             }
         }

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -100,7 +100,8 @@ fn derive_json_schema(
     } else if schema_is_renamed {
         let mut schema_name_fmt = schema_base_name;
         for tp in &type_params {
-            schema_name_fmt.push_str(&format!("{{{}:.0}}", tp));
+            use std::fmt::Write;
+            write!(schema_name_fmt, "{{{}:.0}}", tp).expect("pushing into a string is infallible");
         }
         quote! {
             format!(#schema_name_fmt #(,#type_params=#type_params::schema_name())*)


### PR DESCRIPTION
The automatic type bounds break down when using associated types. For example, for the following code:

```rust
trait MyTrait {
    type Associated;
}

enum MyType {}
impl MyTrait for MyType {
    type Associated = String;
}

#[derive(JsonSchema)]
struct MyContainer<T> where T: MyTrait {
    field: T::Associated,
}
```

schemars will currently generate:

```rust
impl<T> JsonSchema for MyContainer<T> where T: MyTrait + JsonSchema {
  // [snip]
}
```

where the correct bound would be:

```rust
impl<T> JsonSchema for MyContainer<T> where T: MyTrait, T::Associated: JsonSchema {
  // [snip]
}
```

This PR adds an attribute `#[schemars(bound = "T::Associated: JsonSchema")]` that we can use to provide the correct bounds.