### PR TITLE
feat: unique types in root schema

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -41,6 +41,8 @@ default = ["derive"]
 
 derive = ["schemars_derive"]
 
+unique-definitions = []
+
 # Use a different representation for the map type of Schemars.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -104,5 +104,9 @@ required-features = ["url"]
 name = "enumset"
 required-features = ["enumset"]
 
+[[test]]
+name = "conflicting_types"
+required-features = ["unique-definitions"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/examples/conflicting_types.rs
+++ b/schemars/examples/conflicting_types.rs
@@ -26,6 +26,8 @@ pub struct MyStruct {
     pub my_bool: bool,
     pub my_nullable_enum1: Option<mod_1::MyType>,
     pub my_nullable_enum2: Option<mod_2::MyType>,
+    pub my_nullable_enum3: Option<mod_1::MyType>,
+    pub my_nullable_enum4: Option<mod_2::MyType>,
 }
 
 fn main() {

--- a/schemars/examples/conflicting_types.rs
+++ b/schemars/examples/conflicting_types.rs
@@ -1,0 +1,34 @@
+use schemars::schema_for;
+use schemars::JsonSchema;
+
+mod mod_1 {
+    use schemars::JsonSchema;
+
+    #[derive(JsonSchema)]
+    pub struct MyType {
+        pub field: String,
+    }
+}
+
+mod mod_2 {
+    use schemars::JsonSchema;
+
+    #[derive(JsonSchema)]
+    pub enum MyType {
+        StringNewType(String),
+        StructVariant { floats: Vec<f32> },
+    }
+}
+
+#[derive(JsonSchema)]
+pub struct MyStruct {
+    pub my_int: i32,
+    pub my_bool: bool,
+    pub my_nullable_enum1: Option<mod_1::MyType>,
+    pub my_nullable_enum2: Option<mod_2::MyType>,
+}
+
+fn main() {
+    let schema = schema_for!(MyStruct);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/schemars/examples/conflicting_types.schema.json
+++ b/schemars/examples/conflicting_types.schema.json
@@ -33,6 +33,26 @@
           "type": "null"
         }
       ]
+    },
+    "my_nullable_enum3": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/0"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "my_nullable_enum4": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/1"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {

--- a/schemars/examples/conflicting_types.schema.json
+++ b/schemars/examples/conflicting_types.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MyStruct",
+  "type": "object",
+  "required": [
+    "my_bool",
+    "my_int"
+  ],
+  "properties": {
+    "my_bool": {
+      "type": "boolean"
+    },
+    "my_int": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "my_nullable_enum1": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/0"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "my_nullable_enum2": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/1"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "0": {
+      "title": "MyType",
+      "type": "object",
+      "required": [
+        "field"
+      ],
+      "properties": {
+        "field": {
+          "type": "string"
+        }
+      }
+    },
+    "1": {
+      "title": "MyType",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "StringNewType"
+          ],
+          "properties": {
+            "StringNewType": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "StructVariant"
+          ],
+          "properties": {
+            "StructVariant": {
+              "type": "object",
+              "required": [
+                "floats"
+              ],
+              "properties": {
+                "floats": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/schemars/src/gen.rs
+++ b/schemars/src/gen.rs
@@ -548,13 +548,16 @@ impl SchemaGenerator {
     }
 }
 
-/// Returns a unique typeid for any type `T`.
+/// Returns a unique discriminant for the given type.
 ///
-/// This is used to generate unique names for each type in the schema definitions.
+/// This is used to disambiguate between different types which have the same name in the definitions map.
 ///
-/// Caution: This is not consistent across different runs of the program.
+/// Adapted from <https://github.com/sagebind/castaway/pull/6/files#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R30-R37>
 ///
-/// <https://github.com/sagebind/castaway/pull/6/files#diff-23af5356f6001cd3993cd3c801fb7716ea02d1e504081b9fb569332db6107e80R30-R37>
+/// ### Caution
+///
+/// Although the value returned here is unique for every type, it is also runtime-dependent,
+/// therefore, it is not guaranteed to be consistent across runs. Do not export.
 #[inline(always)]
 #[cfg(feature = "unique-definitions")]
 fn type_id_of<T: ?Sized>() -> usize {

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -331,6 +331,12 @@ pub use schemars_derive::*;
 #[doc(hidden)]
 pub use serde_json as _serde_json;
 
+#[cfg(feature = "unique-definitions")]
+pub type TypeId = usize;
+
+#[cfg(not(feature = "unique-definitions"))]
+pub type TypeId = String;
+
 use schema::Schema;
 
 /// A type which can be described as a JSON Schema document.

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -6,7 +6,7 @@ JSON Schema types.
 use crate as schemars;
 #[cfg(feature = "impl_json_schema")]
 use crate::JsonSchema;
-use crate::{Map, Set};
+use crate::{Map, Set, TypeId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::ops::Deref;
@@ -106,7 +106,7 @@ pub struct RootSchema {
     /// See [JSON Schema 8.2.5. Schema Re-Use With "$defs"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5),
     /// and [JSON Schema (draft 07) 9. Schema Re-Use With "definitions"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).
     #[serde(alias = "$defs", skip_serializing_if = "Map::is_empty")]
-    pub definitions: Map<String, Schema>,
+    pub definitions: Map<TypeId, Schema>,
 }
 
 /// A JSON Schema object.

--- a/schemars/src/visit.rs
+++ b/schemars/src/visit.rs
@@ -54,7 +54,7 @@ pub trait Visitor {
 /// Visits all subschemas of the [`RootSchema`].
 pub fn visit_root_schema<V: Visitor + ?Sized>(v: &mut V, root: &mut RootSchema) {
     v.visit_schema_object(&mut root.schema);
-    visit_map_values(v, &mut root.definitions);
+    visit_map_values(v, root.definitions.values_mut());
 }
 
 /// Visits all subschemas of the [`Schema`].
@@ -83,8 +83,8 @@ pub fn visit_schema_object<V: Visitor + ?Sized>(v: &mut V, schema: &mut SchemaOb
     }
 
     if let Some(obj) = &mut schema.object {
-        visit_map_values(v, &mut obj.properties);
-        visit_map_values(v, &mut obj.pattern_properties);
+        visit_map_values(v, obj.properties.values_mut());
+        visit_map_values(v, obj.pattern_properties.values_mut());
         visit_box(v, &mut obj.additional_properties);
         visit_box(v, &mut obj.property_names);
     }
@@ -104,8 +104,11 @@ fn visit_vec<V: Visitor + ?Sized>(v: &mut V, target: &mut Option<Vec<Schema>>) {
     }
 }
 
-fn visit_map_values<V: Visitor + ?Sized>(v: &mut V, target: &mut crate::Map<String, Schema>) {
-    for s in target.values_mut() {
+fn visit_map_values<'a, V: Visitor + ?Sized>(
+    v: &mut V,
+    schemas: impl Iterator<Item = &'a mut Schema>,
+) {
+    for s in schemas {
         v.visit_schema(s)
     }
 }

--- a/schemars/tests/conflicting_types.rs
+++ b/schemars/tests/conflicting_types.rs
@@ -1,0 +1,35 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+mod mod_1 {
+    use schemars::JsonSchema;
+
+    #[derive(JsonSchema)]
+    pub struct MyType {
+        pub field: String,
+    }
+}
+
+mod mod_2 {
+    use schemars::JsonSchema;
+
+    #[derive(JsonSchema)]
+    pub enum MyType {
+        StringNewType(String),
+        StructVariant { floats: Vec<f32> },
+    }
+}
+
+#[derive(JsonSchema)]
+pub struct MyStruct {
+    pub my_int: i32,
+    pub my_bool: bool,
+    pub my_nullable_enum1: Option<mod_1::MyType>,
+    pub my_nullable_enum2: Option<mod_2::MyType>,
+}
+
+#[test]
+fn transparent_struct() -> TestResult {
+    test_default_generated_schema::<MyStruct>("conflicting_types")
+}

--- a/schemars/tests/conflicting_types.rs
+++ b/schemars/tests/conflicting_types.rs
@@ -27,6 +27,8 @@ pub struct MyStruct {
     pub my_bool: bool,
     pub my_nullable_enum1: Option<mod_1::MyType>,
     pub my_nullable_enum2: Option<mod_2::MyType>,
+    pub my_nullable_enum3: Option<mod_1::MyType>,
+    pub my_nullable_enum4: Option<mod_2::MyType>,
 }
 
 #[test]

--- a/schemars/tests/conflicting_types.rs
+++ b/schemars/tests/conflicting_types.rs
@@ -30,6 +30,6 @@ pub struct MyStruct {
 }
 
 #[test]
-fn transparent_struct() -> TestResult {
+fn conflicting_types() -> TestResult {
     test_default_generated_schema::<MyStruct>("conflicting_types")
 }

--- a/schemars/tests/dereference.rs
+++ b/schemars/tests/dereference.rs
@@ -12,7 +12,7 @@ struct Struct {
 fn dereference_struct() {
     let mut gen = SchemaGenerator::default();
     let struct_ref_schema = gen.subschema_for::<Struct>();
-    let struct_schema = gen.definitions().get(&<Struct>::schema_name()).unwrap();
+    let struct_schema = gen.get_schema::<Struct>().unwrap();
 
     assert!(struct_ref_schema.is_ref());
     assert!(!struct_schema.is_ref());

--- a/schemars/tests/expected/conflicting_types.json
+++ b/schemars/tests/expected/conflicting_types.json
@@ -33,6 +33,26 @@
           "type": "null"
         }
       ]
+    },
+    "my_nullable_enum3": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/0"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "my_nullable_enum4": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/1"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {

--- a/schemars/tests/expected/conflicting_types.json
+++ b/schemars/tests/expected/conflicting_types.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MyStruct",
+  "type": "object",
+  "required": [
+    "my_bool",
+    "my_int"
+  ],
+  "properties": {
+    "my_bool": {
+      "type": "boolean"
+    },
+    "my_int": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "my_nullable_enum1": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/0"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "my_nullable_enum2": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/1"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "0": {
+      "title": "MyType",
+      "type": "object",
+      "required": [
+        "field"
+      ],
+      "properties": {
+        "field": {
+          "type": "string"
+        }
+      }
+    },
+    "1": {
+      "title": "MyType",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "StringNewType"
+          ],
+          "properties": {
+            "StringNewType": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "StructVariant"
+          ],
+          "properties": {
+            "StructVariant": {
+              "type": "object",
+              "required": [
+                "floats"
+              ],
+              "properties": {
+                "floats": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "float"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #177.

Instead of using a 1-1 representation of type name to type schema, this patch uses a better discriminant. By casting a generic function pointer to a `usize`, we get a numeric representation of the pointer, which is dependent on the type `T`.

Meaning we can use that discriminant to better disambiguate type signatures.

The discriminant then informs the index in the `definitions` map.

`definitions` then becomes a map of index to `Schema`. With the type name moved inside the schema. Effectively a `Vec<Schema>` but adhering to the spec of it being a map.