### PR TITLE
Support types with const generics

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -33,6 +33,7 @@ bigdecimal = { version = "0.3", default-features = false, optional = true }
 enumset = { version = "1.0", optional = true }
 
 [dev-dependencies]
+if_rust_version = "1.0"
 pretty_assertions = "1.2.1"
 trybuild = "1.0"
 

--- a/schemars/tests/expected/schema-name-const-generics.json
+++ b/schemars/tests/expected/schema-name-const-generics.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "const-generics-z-42",
+  "type": "object",
+  "required": [
+    "foo"
+  ],
+  "properties": {
+    "foo": {
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/schemars/tests/expected/schema-name-mixed-generics.json
+++ b/schemars/tests/expected/schema-name-mixed-generics.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MixedGenericStruct_for_MyStruct_for_int32_and_Null_and_Boolean_and_Array_of_String_and_42_and_z",
+  "type": "object",
+  "required": [
+    "foo",
+    "generic"
+  ],
+  "properties": {
+    "foo": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "generic": {
+      "$ref": "#/definitions/MyStruct_for_int32_and_Null_and_Boolean_and_Array_of_String"
+    }
+  },
+  "definitions": {
+    "MySimpleStruct": {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "MyStruct_for_int32_and_Null_and_Boolean_and_Array_of_String": {
+      "type": "object",
+      "required": [
+        "inner",
+        "t",
+        "u",
+        "v",
+        "w"
+      ],
+      "properties": {
+        "inner": {
+          "$ref": "#/definitions/MySimpleStruct"
+        },
+        "t": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "u": {
+          "type": "null"
+        },
+        "v": {
+          "type": "boolean"
+        },
+        "w": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemars/tests/schema_name.rs
+++ b/schemars/tests/schema_name.rs
@@ -50,28 +50,32 @@ fn overriden_with_rename_multiple_type_params() -> TestResult {
     )
 }
 
-#[allow(dead_code)]
-#[derive(JsonSchema)]
-#[schemars(rename = "const-generics-{BAR}-")]
-struct ConstGenericStruct<const FOO: usize, const BAR: char> {
-    foo: i32,
-}
+if_rust_version::if_rust_version! {
+    >= 1.51 {
+        #[allow(dead_code)]
+        #[derive(JsonSchema)]
+        #[schemars(rename = "const-generics-{BAR}-")]
+        struct ConstGenericStruct<const FOO: usize, const BAR: char> {
+            foo: i32,
+        }
 
-#[test]
-fn overriden_with_rename_const_generics() -> TestResult {
-    test_default_generated_schema::<ConstGenericStruct<42, 'z'>>("schema-name-const-generics")
-}
+        #[test]
+        fn overriden_with_rename_const_generics() -> TestResult {
+            test_default_generated_schema::<ConstGenericStruct<42, 'z'>>("schema-name-const-generics")
+        }
 
-#[allow(dead_code)]
-#[derive(JsonSchema)]
-struct MixedGenericStruct<T, const FOO: usize, const BAR: char> {
-    generic: T,
-    foo: i32,
-}
+        #[allow(dead_code)]
+        #[derive(JsonSchema)]
+        struct MixedGenericStruct<T, const FOO: usize, const BAR: char> {
+            generic: T,
+            foo: i32,
+        }
 
-#[test]
-fn default_name_mixed_generics() -> TestResult {
-    test_default_generated_schema::<MixedGenericStruct<MyStruct<i32, (), bool, Vec<String>>, 42, 'z'>>(
-        "schema-name-mixed-generics",
-    )
+        #[test]
+        fn default_name_mixed_generics() -> TestResult {
+            test_default_generated_schema::<
+                MixedGenericStruct<MyStruct<i32, (), bool, Vec<String>>, 42, 'z'>,
+            >("schema-name-mixed-generics")
+        }
+    }
 }

--- a/schemars/tests/schema_name.rs
+++ b/schemars/tests/schema_name.rs
@@ -49,3 +49,29 @@ fn overriden_with_rename_multiple_type_params() -> TestResult {
         "schema-name-custom",
     )
 }
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "const-generics-{BAR}-")]
+struct ConstGenericStruct<const FOO: usize, const BAR: char> {
+    foo: i32,
+}
+
+#[test]
+fn overriden_with_rename_const_generics() -> TestResult {
+    test_default_generated_schema::<ConstGenericStruct<42, 'z'>>("schema-name-const-generics")
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct MixedGenericStruct<T, const FOO: usize, const BAR: char> {
+    generic: T,
+    foo: i32,
+}
+
+#[test]
+fn default_name_mixed_generics() -> TestResult {
+    test_default_generated_schema::<MixedGenericStruct<MyStruct<i32, (), bool, Vec<String>>, 42, 'z'>>(
+        "schema-name-mixed-generics",
+    )
+}


### PR DESCRIPTION
Before this change, [const generic](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html) parameters were ignored when generating a title for a type's schema.

I propose we treat const generic parameters similar to generic type parameters. Since const generics are simple expressions that fit into the format macro arguments, we can use the literal value in the name of the type. This parameterizes the unique permutations of a type and it's const generics as separate definitions, in case those const generics are used as properties of the schema.

Tests were added to ensure naming works, including templating the overwritten with the `rename` attribute.

Note: Since the MSRV is 1.45, I added a check around the test cases involving const generics. Since this change doesn't actually *use* const generics (landed in 1.51), we can still support if the user's rust version supports the feature. I was looking to use const generics for the JsonSchema array impls ([T; SIZE]), but we cannot do that with the current MSRV :)