### PR TITLE
Fix Clippy lint warnings & Added CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  ci:
+  test:
     runs-on: ubuntu-latest
     env:
       # work-around https://github.com/rust-lang/cargo/issues/10303
@@ -51,3 +51,25 @@ jobs:
         run: cargo test --verbose --all-features --no-fail-fast
         continue-on-error: ${{ matrix.allow_failure }}
         working-directory: ./schemars_derive
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Format
+      run: cargo fmt -- --check
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Linting
+      run: cargo clippy
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Audit
+      run: |
+        cargo update
+        cargo audit
+      # Allowed to fail but this will notify us that some dependency might need an update.
+      continue-on-error: true

--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -171,8 +171,5 @@ fn is_null_type(schema: &Schema) -> bool {
         Schema::Object(s) => s,
         _ => return false,
     };
-    match &s.instance_type {
-        Some(SingleOrVec::Single(t)) if **t == InstanceType::Null => true,
-        _ => false,
-    }
+    matches!(&s.instance_type, Some(SingleOrVec::Single(t)) if **t == InstanceType::Null)
 }

--- a/schemars/src/gen.rs
+++ b/schemars/src/gen.rs
@@ -17,6 +17,7 @@ use std::{any::Any, collections::HashSet, fmt::Debug};
 ///
 /// The default settings currently conform to [JSON Schema Draft 7](https://json-schema.org/specification-links.html#draft-7), but this is liable to change in a future version of Schemars if support for other JSON Schema versions is added.
 /// If you require your generated schemas to conform to draft 7, consider using the [`draft07`](#method.draft07) method.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct SchemaSettings {
     /// If `true`, schemas for [`Option<T>`](Option) will include a `nullable` property.
@@ -45,7 +46,6 @@ pub struct SchemaSettings {
     ///
     /// Defaults to `false`.
     pub inline_subschemas: bool,
-    _hidden: (),
 }
 
 impl Default for SchemaSettings {
@@ -64,7 +64,6 @@ impl SchemaSettings {
             meta_schema: Some("http://json-schema.org/draft-07/schema#".to_owned()),
             visitors: vec![Box::new(RemoveRefSiblings)],
             inline_subschemas: false,
-            _hidden: (),
         }
     }
 
@@ -77,7 +76,6 @@ impl SchemaSettings {
             meta_schema: Some("https://json-schema.org/draft/2019-09/schema".to_owned()),
             visitors: Vec::default(),
             inline_subschemas: false,
-            _hidden: (),
         }
     }
 
@@ -101,7 +99,6 @@ impl SchemaSettings {
                 }),
             ],
             inline_subschemas: false,
-            _hidden: (),
         }
     }
 
@@ -263,7 +260,8 @@ impl SchemaGenerator {
     /// The keys of the returned `Map` are the [schema names](JsonSchema::schema_name), and the values are the schemas
     /// themselves.
     pub fn take_definitions(&mut self) -> Map<String, Schema> {
-        std::mem::replace(&mut self.definitions, Map::default())
+        // Set `self.definitions` to the default value (empty).
+        std::mem::take(&mut self.definitions)
     }
 
     /// Returns an iterator over the [visitors](SchemaSettings::visitors) being used by this `SchemaGenerator`.

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -25,7 +25,7 @@ macro_rules! decimal_impl {
     };
 }
 
-#[cfg(feature="rust_decimal")]
+#[cfg(feature = "rust_decimal")]
 decimal_impl!(rust_decimal::Decimal);
-#[cfg(feature="bigdecimal")]
+#[cfg(feature = "bigdecimal")]
 decimal_impl!(bigdecimal::BigDecimal);

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -257,7 +257,7 @@ impl From<Schema> for SchemaObject {
 }
 
 /// Properties which annotate a [`SchemaObject`] which typically have no effect when an object is being validated against the schema.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 pub struct Metadata {
@@ -386,7 +386,7 @@ pub struct NumberValidation {
 }
 
 /// Properties of a [`SchemaObject`] which define validation assertions for strings.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default)]
 pub struct StringValidation {

--- a/schemars/src/ser.rs
+++ b/schemars/src/ser.rs
@@ -128,7 +128,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         self.serialize_none()
     }
 
-    fn serialize_some<T: ?Sized>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
@@ -153,7 +153,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
         if self.gen.settings().option_add_null_type {
             schema = match schema {
                 Schema::Bool(true) => Schema::Bool(true),
-                Schema::Bool(false) => <()>::json_schema(&mut self.gen),
+                Schema::Bool(false) => <()>::json_schema(self.gen),
                 Schema::Object(SchemaObject {
                     instance_type: Some(ref mut instance_type),
                     ..
@@ -163,7 +163,7 @@ impl<'a> serde::Serializer for Serializer<'a> {
                 }
                 schema => SchemaObject {
                     subschemas: Some(Box::new(SubschemaValidation {
-                        any_of: Some(vec![schema, <()>::json_schema(&mut self.gen)]),
+                        any_of: Some(vec![schema, <()>::json_schema(self.gen)]),
                         ..Default::default()
                     })),
                     ..Default::default()

--- a/schemars/tests/bound.rs
+++ b/schemars/tests/bound.rs
@@ -18,7 +18,10 @@ impl Iterator for MyIterator {
 // which MyIterator does not.
 #[derive(JsonSchema)]
 #[schemars(bound = "T::Item: JsonSchema", rename = "MyContainer")]
-pub struct MyContainer<T> where T: Iterator {
+pub struct MyContainer<T>
+where
+    T: Iterator,
+{
     pub associated: T::Item,
     pub generic: PhantomData<T>,
 }

--- a/schemars/tests/examples.rs
+++ b/schemars/tests/examples.rs
@@ -17,7 +17,7 @@ fn eight() -> i32 {
     8
 }
 
-fn null() -> () {}
+fn null() {}
 
 #[test]
 fn examples() -> TestResult {

--- a/schemars/tests/validate.rs
+++ b/schemars/tests/validate.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use util::*;
 
 // In real code, this would typically be a Regex, potentially created in a `lazy_static!`.
-static STARTS_WITH_HELLO: &'static str = r"^[Hh]ello\b";
+static STARTS_WITH_HELLO: &str = r"^[Hh]ello\b";
 
 const MIN: u32 = 1;
 const MAX: u32 = 1000;

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -69,10 +69,7 @@ impl<'a> Variant<'a> {
     }
 
     pub fn is_unit(&self) -> bool {
-        match self.style {
-            serde_ast::Style::Unit => true,
-            _ => false,
-        }
+        matches!(self.style, serde_ast::Style::Unit)
     }
 }
 

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -27,10 +27,11 @@ pub struct Attrs {
     pub examples: Vec<syn::Path>,
     pub repr: Option<syn::Type>,
     pub crate_name: Option<syn::Path>,
-    pub is_renamed: bool
+    pub is_renamed: bool,
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum WithAttr {
     Type(syn::Type),
     Function(syn::Path),
@@ -153,9 +154,7 @@ impl Attrs {
                     }
                 }
 
-                Meta(NameValue(m)) if m.path.is_ident("rename") => {
-                    self.is_renamed = true
-                }
+                Meta(NameValue(m)) if m.path.is_ident("rename") => self.is_renamed = true,
 
                 Meta(NameValue(m)) if m.path.is_ident("crate") && attr_type == "schemars" => {
                     if let Ok(p) = parse_lit_into_path(errors, attr_type, "crate", &m.lit) {
@@ -192,6 +191,7 @@ impl Attrs {
     }
 
     pub fn is_default(&self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match self {
             Self {
                 with: None,

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -46,14 +46,14 @@ pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), Vec<syn::
 
 fn process_serde_variant_attrs<'a>(ctxt: &Ctxt, variants: impl Iterator<Item = &'a mut Variant>) {
     for v in variants {
-        process_attrs(&ctxt, &mut v.attrs);
-        process_serde_field_attrs(&ctxt, v.fields.iter_mut());
+        process_attrs(ctxt, &mut v.attrs);
+        process_serde_field_attrs(ctxt, v.fields.iter_mut());
     }
 }
 
 fn process_serde_field_attrs<'a>(ctxt: &Ctxt, fields: impl Iterator<Item = &'a mut Field>) {
     for f in fields {
-        process_attrs(&ctxt, &mut f.attrs);
+        process_attrs(ctxt, &mut f.attrs);
     }
 }
 
@@ -71,10 +71,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
     // Copy appropriate #[schemars(...)] attributes to #[serde(...)] attributes
     let (mut serde_meta, mut schemars_meta_names): (Vec<_>, HashSet<_>) = schemars_attrs
         .iter()
-        .flat_map(|at| get_meta_items(&ctxt, at))
+        .flat_map(|at| get_meta_items(ctxt, at))
         .flatten()
         .filter_map(|meta| {
-            let keyword = get_meta_ident(&ctxt, &meta).ok()?;
+            let keyword = get_meta_ident(ctxt, &meta).ok()?;
             if keyword.ends_with("with") || !SERDE_KEYWORDS.contains(&keyword.as_ref()) {
                 None
             } else {
@@ -91,10 +91,10 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
     // Re-add #[serde(...)] attributes that weren't overridden by #[schemars(...)] attributes
     for meta in serde_attrs
         .into_iter()
-        .flat_map(|at| get_meta_items(&ctxt, &at))
+        .flat_map(|at| get_meta_items(ctxt, &at))
         .flatten()
     {
-        if let Ok(i) = get_meta_ident(&ctxt, &meta) {
+        if let Ok(i) = get_meta_ident(ctxt, &meta) {
             if !schemars_meta_names.contains(&i)
                 && SERDE_KEYWORDS.contains(&i.as_ref())
                 && i != "bound"

--- a/schemars_derive/src/attr/validation.rs
+++ b/schemars_derive/src/attr/validation.rs
@@ -112,7 +112,7 @@ impl ValidationAttrs {
                                 } else if self.length_equal.is_some() {
                                     mutual_exclusive_error(&nv.path, "equal")
                                 } else {
-                                    self.length_min = str_or_num_to_expr(&errors, "min", &nv.lit);
+                                    self.length_min = str_or_num_to_expr(errors, "min", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("max") => {
@@ -121,7 +121,7 @@ impl ValidationAttrs {
                                 } else if self.length_equal.is_some() {
                                     mutual_exclusive_error(&nv.path, "equal")
                                 } else {
-                                    self.length_max = str_or_num_to_expr(&errors, "max", &nv.lit);
+                                    self.length_max = str_or_num_to_expr(errors, "max", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("equal") => {
@@ -133,14 +133,14 @@ impl ValidationAttrs {
                                     mutual_exclusive_error(&nv.path, "max")
                                 } else {
                                     self.length_equal =
-                                        str_or_num_to_expr(&errors, "equal", &nv.lit);
+                                        str_or_num_to_expr(errors, "equal", &nv.lit);
                                 }
                             }
                             meta => {
                                 if !ignore_errors {
                                     errors.error_spanned_by(
                                         meta,
-                                        format!("unknown item in schemars length attribute"),
+                                        "unknown item in schemars length attribute".to_owned(),
                                     );
                                 }
                             }
@@ -155,21 +155,21 @@ impl ValidationAttrs {
                                 if self.range_min.is_some() {
                                     duplicate_error(&nv.path)
                                 } else {
-                                    self.range_min = str_or_num_to_expr(&errors, "min", &nv.lit);
+                                    self.range_min = str_or_num_to_expr(errors, "min", &nv.lit);
                                 }
                             }
                             NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("max") => {
                                 if self.range_max.is_some() {
                                     duplicate_error(&nv.path)
                                 } else {
-                                    self.range_max = str_or_num_to_expr(&errors, "max", &nv.lit);
+                                    self.range_max = str_or_num_to_expr(errors, "max", &nv.lit);
                                 }
                             }
                             meta => {
                                 if !ignore_errors {
                                     errors.error_spanned_by(
                                         meta,
-                                        format!("unknown item in schemars range attribute"),
+                                        "unknown item in schemars range attribute".to_owned(),
                                     );
                                 }
                             }
@@ -247,7 +247,8 @@ impl ValidationAttrs {
                                         if !ignore_errors {
                                             errors.error_spanned_by(
                                                 meta,
-                                                format!("unknown item in schemars regex attribute"),
+                                                "unknown item in schemars regex attribute"
+                                                    .to_owned(),
                                             );
                                         }
                                     }
@@ -261,8 +262,8 @@ impl ValidationAttrs {
                     if path.is_ident("contains") =>
                 {
                     match (&self.contains, &self.regex) {
-                        (Some(_), _) => duplicate_error(&path),
-                        (None, Some(_)) => mutual_exclusive_error(&path, "regex"),
+                        (Some(_), _) => duplicate_error(path),
+                        (None, Some(_)) => mutual_exclusive_error(path, "regex"),
                         (None, None) => {
                             self.contains = get_lit_str(errors, attr_type, "contains", lit)
                                 .map(|litstr| litstr.value())
@@ -292,9 +293,8 @@ impl ValidationAttrs {
                                         if !ignore_errors {
                                             errors.error_spanned_by(
                                                 meta,
-                                                format!(
-                                                    "unknown item in schemars contains attribute"
-                                                ),
+                                                "unknown item in schemars contains attribute"
+                                                    .to_owned(),
                                             );
                                         }
                                     }
@@ -316,11 +316,7 @@ impl ValidationAttrs {
         let mut object_validation = Vec::new();
         let mut string_validation = Vec::new();
 
-        if let Some(length_min) = self
-            .length_min
-            .as_ref()
-            .or_else(|| self.length_equal.as_ref())
-        {
+        if let Some(length_min) = self.length_min.as_ref().or(self.length_equal.as_ref()) {
             string_validation.push(quote! {
                 validation.min_length = Some(#length_min as u32);
             });
@@ -329,11 +325,7 @@ impl ValidationAttrs {
             });
         }
 
-        if let Some(length_max) = self
-            .length_max
-            .as_ref()
-            .or_else(|| self.length_equal.as_ref())
-        {
+        if let Some(length_max) = self.length_max.as_ref().or(self.length_equal.as_ref()) {
             string_validation.push(quote! {
                 validation.max_length = Some(#length_max as u32);
             });

--- a/schemars_derive/src/regex_syntax.rs
+++ b/schemars_derive/src/regex_syntax.rs
@@ -44,6 +44,7 @@ fn escape_into(text: &str, buf: &mut String) {
 }
 
 fn is_meta_character(c: char) -> bool {
+    #[allow(clippy::match_like_matches_macro)]
     match c {
         '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
         | '#' | '&' | '-' | '~' => true,


### PR DESCRIPTION
Various fixes for Clippy warnings and added CI steps: Format, Linting and Audit.

There are no changes to any API surfaces.
But `SchemaSettings` uses `#[non_exhaustive]` instead of ` _hidden: (),`. This however does not change the external API.

Added some opt-out statements for some Clippy warnings because they made things more complicated or less readable.