### PR TITLE
Docs processing - don't break markdown input

### DIFF
--- a/schemars/tests/expected/doc_comments_enum.json
+++ b/schemars/tests/expected/doc_comments_enum.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "This is the enum's title",
-  "description": "This is the enum's description.",
+  "description": "This is\nthe enum's description.",
   "oneOf": [
     {
       "type": "string",
@@ -30,7 +30,7 @@
           "properties": {
             "my_nullable_string": {
               "title": "A nullable string",
-              "description": "This field is a nullable string.\n\nThis is the second line!\n\nAnd this is the third!",
+              "description": "This field is a nullable string.\n\nThis\nis\nthe second\nline!\n\n\n\n\nAnd this is the third!",
               "type": [
                 "string",
                 "null"

--- a/schemars/tests/expected/schema-2019_09.json
+++ b/schemars/tests/expected/schema-2019_09.json
@@ -12,14 +12,14 @@
       ]
     },
     "definitions": {
-      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still serialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5), and [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
+      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still\nserialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5),\nand [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Schema"
       }
     },
     "type": {
-      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
       "anyOf": [
         {
           "$ref": "#/definitions/SingleOrVec_for_InstanceType"
@@ -361,7 +361,7 @@
       "description": "A JSON Schema.",
       "anyOf": [
         {
-          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false` matches nothing (always fails validation).",
+          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false`\nmatches nothing (always fails validation).",
           "type": "boolean"
         },
         {
@@ -375,7 +375,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
           "anyOf": [
             {
               "$ref": "#/definitions/SingleOrVec_for_InstanceType"

--- a/schemars/tests/expected/schema-openapi3.json
+++ b/schemars/tests/expected/schema-openapi3.json
@@ -10,14 +10,14 @@
       "nullable": true
     },
     "definitions": {
-      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still serialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5), and [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
+      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still\nserialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5),\nand [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/components/schemas/Schema"
       }
     },
     "type": {
-      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
       "allOf": [
         {
           "$ref": "#/components/schemas/SingleOrVec_for_InstanceType"
@@ -297,7 +297,7 @@
       "description": "A JSON Schema.",
       "anyOf": [
         {
-          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false` matches nothing (always fails validation).",
+          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false`\nmatches nothing (always fails validation).",
           "type": "boolean"
         },
         {
@@ -315,7 +315,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
           "allOf": [
             {
               "$ref": "#/components/schemas/SingleOrVec_for_InstanceType"

--- a/schemars/tests/expected/schema.json
+++ b/schemars/tests/expected/schema.json
@@ -12,14 +12,14 @@
       ]
     },
     "definitions": {
-      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still serialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5), and [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
+      "description": "The `definitions` keyword.\n\nIn JSON Schema draft 2019-09 this was replaced by $defs, but in Schemars this is still\nserialized as `definitions` for backward-compatibility.\n\nSee [JSON Schema 8.2.5. Schema Re-Use With \"$defs\"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-8.2.5),\nand [JSON Schema (draft 07) 9. Schema Re-Use With \"definitions\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-9).",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Schema"
       }
     },
     "type": {
-      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+      "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
       "anyOf": [
         {
           "$ref": "#/definitions/SingleOrVec_for_InstanceType"
@@ -361,7 +361,7 @@
       "description": "A JSON Schema.",
       "anyOf": [
         {
-          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false` matches nothing (always fails validation).",
+          "description": "A trivial boolean JSON Schema.\n\nThe schema `true` matches everything (always passes validation), whereas the schema `false`\nmatches nothing (always fails validation).",
           "type": "boolean"
         },
         {
@@ -379,7 +379,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1) and [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
+          "description": "The `type` keyword.\n\nSee [JSON Schema Validation 6.1.1. \"type\"](https://tools.ietf.org/html/draft-handrews-json-schema-validation-02#section-6.1.1)\nand [JSON Schema 4.2.1. Instance Data Model](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-4.2.1).",
           "anyOf": [
             {
               "$ref": "#/definitions/SingleOrVec_for_InstanceType"

--- a/schemars_derive/src/attr/doc.rs
+++ b/schemars_derive/src/attr/doc.rs
@@ -1,76 +1,67 @@
 use syn::{Attribute, Lit::Str, Meta::NameValue, MetaNameValue};
 
 pub fn get_title_and_desc_from_doc(attrs: &[Attribute]) -> (Option<String>, Option<String>) {
-    let doc = match get_doc(attrs) {
-        None => return (None, None),
-        Some(doc) => doc,
-    };
+    let mut lines = get_lines(attrs);
 
-    if doc.starts_with('#') {
-        let mut split = doc.splitn(2, '\n');
-        let title = split
-            .next()
-            .unwrap()
-            .trim_start_matches('#')
-            .trim()
-            .to_owned();
-        let maybe_desc = split.next().and_then(merge_description_lines);
-        (none_if_empty(title), maybe_desc)
-    } else {
-        (None, merge_description_lines(&doc))
+    let title = lines
+        .get(0)
+        .as_ref()
+        .filter(|line| line.starts_with('#'))
+        .map(|line| line.trim_start_matches('#').trim().to_owned())
+        .and_then(none_if_empty);
+
+    if title.is_some() {
+        lines.remove(0);
+        pop_front_empty_lines(&mut lines);
     }
-}
 
-fn merge_description_lines(doc: &str) -> Option<String> {
-    let desc = doc
-        .trim()
-        .split("\n\n")
-        .filter_map(|line| none_if_empty(line.trim().replace('\n', " ")))
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    none_if_empty(desc)
-}
-
-fn get_doc(attrs: &[Attribute]) -> Option<String> {
-    let attrs = attrs
-        .iter()
-        .filter_map(|attr| {
-            if !attr.path.is_ident("doc") {
-                return None;
-            }
-
-            let meta = attr.parse_meta().ok()?;
-            if let NameValue(MetaNameValue { lit: Str(s), .. }) = meta {
-                return Some(s.value());
-            }
-
-            None
-        })
-        .collect::<Vec<_>>();
-
-    let mut lines = attrs
-        .iter()
-        .flat_map(|a| a.split('\n'))
-        .map(str::trim)
-        .skip_while(|s| s.is_empty())
-        .collect::<Vec<_>>();
-
-    if let Some(&"") = lines.last() {
+    while let Some(true) = lines.last().map(|x| x.is_empty()) {
         lines.pop();
+    }
+
+    (title, none_if_empty(lines.join("\n")))
+}
+
+fn get_lines(attrs: &[Attribute]) -> Vec<String> {
+    let mut lines = vec![];
+    let mut all_starts_with_asterisk = true;
+
+    for attr in attrs.iter() {
+        if !attr.path.is_ident("doc") {
+            continue;
+        }
+
+        if let Ok(NameValue(MetaNameValue { lit: Str(s), .. })) = attr.parse_meta() {
+            let value = s.value();
+
+            for line in value.split('\n') {
+                let line = line.trim();
+
+                if !line.is_empty() {
+                    all_starts_with_asterisk = line.starts_with('*');
+                }
+
+                lines.push(line.to_owned());
+            }
+        }
     }
 
     // Added for backward-compatibility, but perhaps we shouldn't do this
     // https://github.com/rust-lang/rust/issues/32088
-    if lines.iter().all(|l| l.starts_with('*')) {
+    if all_starts_with_asterisk {
         for line in lines.iter_mut() {
-            *line = line[1..].trim()
+            *line = line.trim_start_matches('*').trim().to_owned();
         }
-        while let Some(&"") = lines.first() {
-            lines.remove(0);
-        }
-    };
+    }
+    pop_front_empty_lines(&mut lines);
 
-    none_if_empty(lines.join("\n"))
+    lines
+}
+
+fn pop_front_empty_lines(lines: &mut Vec<String>) {
+    while let Some(true) = lines.first().map(|x| x.is_empty()) {
+        lines.remove(0);
+    }
 }
 
 fn none_if_empty(s: String) -> Option<String> {


### PR DESCRIPTION
This PR makes Markdown parsers happier by disabling line merging.