### PR TITLE
Add setting to enable strict inlining.

### DIFF
--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -25,7 +25,7 @@ macro_rules! decimal_impl {
     };
 }
 
-#[cfg(feature="rust_decimal")]
+#[cfg(feature = "rust_decimal")]
 decimal_impl!(rust_decimal::Decimal);
-#[cfg(feature="bigdecimal")]
+#[cfg(feature = "bigdecimal")]
 decimal_impl!(bigdecimal::BigDecimal);

--- a/schemars/tests/bound.rs
+++ b/schemars/tests/bound.rs
@@ -18,7 +18,10 @@ impl Iterator for MyIterator {
 // which MyIterator does not.
 #[derive(JsonSchema)]
 #[schemars(bound = "T::Item: JsonSchema", rename = "MyContainer")]
-pub struct MyContainer<T> where T: Iterator {
+pub struct MyContainer<T>
+where
+    T: Iterator,
+{
     pub associated: T::Item,
     pub generic: PhantomData<T>,
 }

--- a/schemars/tests/expected/struct-recursive-strict-inline.json
+++ b/schemars/tests/expected/struct-recursive-strict-inline.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecursiveStruct",
+  "type": "object",
+  "required": [
+    "foo"
+  ],
+  "properties": {
+    "foo": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/schemars/tests/expected/struct-recursive.json
+++ b/schemars/tests/expected/struct-recursive.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RecursiveStruct",
+  "type": "object",
+  "required": [
+    "foo"
+  ],
+  "properties": {
+    "foo": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RecursiveStruct"
+      }
+    }
+  },
+  "definitions": {
+    "RecursiveStruct": {
+      "type": "object",
+      "required": [
+        "foo"
+      ],
+      "properties": {
+        "foo": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RecursiveStruct"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemars/tests/struct.rs
+++ b/schemars/tests/struct.rs
@@ -1,5 +1,5 @@
 mod util;
-use schemars::JsonSchema;
+use schemars::{gen::SchemaSettings, JsonSchema};
 use util::*;
 
 // Ensure that schemars_derive uses the full path to std::string::String
@@ -40,4 +40,22 @@ pub struct Unit;
 #[test]
 fn struct_unit() -> TestResult {
     test_default_generated_schema::<Unit>("struct-unit")
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct RecursiveStruct {
+    foo: Vec<RecursiveStruct>,
+}
+
+#[test]
+fn struct_recursive() -> TestResult {
+    test_default_generated_schema::<RecursiveStruct>("struct-recursive")
+}
+
+#[test]
+fn struct_recursive_strict_inline() -> TestResult {
+    let mut settings = SchemaSettings::default();
+    settings.strict_inline_subschemas = true;
+    test_generated_schema::<RecursiveStruct>("struct-recursive-strict-inline", settings)
 }

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -27,7 +27,7 @@ pub struct Attrs {
     pub examples: Vec<syn::Path>,
     pub repr: Option<syn::Type>,
     pub crate_name: Option<syn::Path>,
-    pub is_renamed: bool
+    pub is_renamed: bool,
 }
 
 #[derive(Debug)]
@@ -153,9 +153,7 @@ impl Attrs {
                     }
                 }
 
-                Meta(NameValue(m)) if m.path.is_ident("rename") => {
-                    self.is_renamed = true
-                }
+                Meta(NameValue(m)) if m.path.is_ident("rename") => self.is_renamed = true,
 
                 Meta(NameValue(m)) if m.path.is_ident("crate") && attr_type == "schemars" => {
                     if let Ok(p) = parse_lit_into_path(errors, attr_type, "crate", &m.lit) {

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -95,26 +95,27 @@ fn derive_json_schema(
 
     // FIXME improve handling of generic type params which may not implement JsonSchema
     let type_params: Vec<_> = cont.generics.type_params().map(|ty| &ty.ident).collect();
-    let schema_name = if type_params.is_empty() || (cont.attrs.is_renamed && !schema_base_name.contains('{')) {
-        quote! {
-            #schema_base_name.to_owned()
-        }
-    } else if cont.attrs.is_renamed {
-        let mut schema_name_fmt = schema_base_name;
-        for tp in &type_params {
-            schema_name_fmt.push_str(&format!("{{{}:.0}}", tp));
-        }
-        quote! {
-            format!(#schema_name_fmt #(,#type_params=#type_params::schema_name())*)
-        }
-    } else {
-        let mut schema_name_fmt = schema_base_name;
-        schema_name_fmt.push_str("_for_{}");
-        schema_name_fmt.push_str(&"_and_{}".repeat(type_params.len() - 1));
-        quote! {
-            format!(#schema_name_fmt #(,#type_params::schema_name())*)
-        }
-    };
+    let schema_name =
+        if type_params.is_empty() || (cont.attrs.is_renamed && !schema_base_name.contains('{')) {
+            quote! {
+                #schema_base_name.to_owned()
+            }
+        } else if cont.attrs.is_renamed {
+            let mut schema_name_fmt = schema_base_name;
+            for tp in &type_params {
+                schema_name_fmt.push_str(&format!("{{{}:.0}}", tp));
+            }
+            quote! {
+                format!(#schema_name_fmt #(,#type_params=#type_params::schema_name())*)
+            }
+        } else {
+            let mut schema_name_fmt = schema_base_name;
+            schema_name_fmt.push_str("_for_{}");
+            schema_name_fmt.push_str(&"_and_{}".repeat(type_params.len() - 1));
+            quote! {
+                format!(#schema_name_fmt #(,#type_params::schema_name())*)
+            }
+        };
 
     let schema_expr = if repr {
         schema_exprs::expr_for_repr(&cont).map_err(|e| vec![e])?


### PR DESCRIPTION
When `strict_inline_subschemas` is `true`, instead of referencing the schema, the type information are not applied instead.

This is useful for kubernetes, where the applying schemas with $ref is not supported at all.


The issue comes up when a crd contains a data type that was not designed for k8s like I'm currently having with the keycloak admin API.