### PR TITLE
Set a reasonable min version for serde_json

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 [dependencies]
 schemars_derive = { version = "=0.8.11", optional = true, path = "../schemars_derive" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.25"
 dyn-clone = "1.0"
 
 chrono = { version = "0.4", default-features = false, optional = true }


### PR DESCRIPTION
The goal is use be able to compile a project using schemars with `cargo +nightly build -Zminimal-versions` to ensure the min versions are all set correctly. 

Here serde_json was set to ^1.0.0 but this is not the actual min version we need. serde_json 1.0.25 brings in the `json!` macro that is used here (https://github.com/serde-rs/json/releases/tag/v1.0.25).