### PR TITLE
feat: add feature for time crate

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 dyn-clone = "1.0"
 
 chrono = { version = "0.4", default-features = false, optional = true }
+time3 = { version = "0.3", default-features = false, optional = true, package = "time" }
 indexmap = { version = "1.2", features = ["serde-1"], optional = true }
 either = { version = "1.3", default-features = false, optional = true }
 uuid08 = { version = "0.8", default-features = false, optional = true, package = "uuid" }

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -65,6 +65,8 @@ mod serdejson;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 mod time;
+#[cfg(feature = "time3")]
+mod time3;
 mod tuple;
 #[cfg(feature = "url")]
 mod url;

--- a/schemars/src/json_schema_impls/time3.rs
+++ b/schemars/src/json_schema_impls/time3.rs
@@ -1,0 +1,21 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use time3::OffsetDateTime;
+
+impl JsonSchema for OffsetDateTime {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "DateTime".to_string()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            format: Some("date-time".to_string()),
+            ..Default::default()
+        }
+        .into()
+    }
+}


### PR DESCRIPTION
This PR adds support for `OffsetDateTime` from the `time` crate.

As there is already a `time` feature/module I chose `time3` for this new feature. Maybe it would be better to rename the existing `time` feature/module `std-time` and my new one `time`, but this is a breaking change we could save for later (1.0) after a deprecation cycle or such.