### PR TITLE
Use IndexSet in preserve_order

### DIFF
--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -139,7 +139,10 @@ where
     }
 }
 
-impl<T: Ord> Merge for Set<T> {
+impl<T> Merge for Set<T>
+where
+    T: std::hash::Hash + Ord,
+{
     fn merge(mut self, other: Self) -> Self {
         self.extend(other);
         self

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -295,9 +295,13 @@ pub type Map<K, V> = std::collections::BTreeMap<K, V>;
 pub type Map<K, V> = indexmap::IndexMap<K, V>;
 /// The set type used by schemars types.
 ///
-/// Currently a `BTreeSet`, but this may change to a different implementation
+/// Currently a `BTreeSet` or `IndexSet`, but this may change to a different implementation
 /// with a similar interface in a future version of schemars.
+/// The `IndexSet` will be used when the `preserve_order` feature flag is set.
+#[cfg(not(feature = "preserve_order"))]
 pub type Set<T> = std::collections::BTreeSet<T>;
+#[cfg(feature = "preserve_order")]
+pub type Set<T> = indexmap::IndexSet<T>;
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
 //


### PR DESCRIPTION
This PR uses `IndexSet` under the `preserve_order` feature, which preserves the order of required elements.

BREAKING:
- `Set<T>` requires `T: Hash` to implement `Merge`