### PR TITLE
support const generics

### DIFF
--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -36,6 +36,7 @@ macro_rules! forward_impl {
 }
 
 mod array;
+pub use array::EmptyArray;
 #[cfg(feature = "arrayvec05")]
 mod arrayvec05;
 #[cfg(feature = "arrayvec07")]

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -310,6 +310,7 @@ pub type MapEntry<'a, K, V> = indexmap::map::Entry<'a, K, V>;
 
 mod flatten;
 mod json_schema_impls;
+pub use json_schema_impls::EmptyArray;
 mod ser;
 #[macro_use]
 mod macros;


### PR DESCRIPTION
I'd like to support const generic arrays, and it didn't seem to hard to implement, so I made a quick PR - of course, I'm not 100% familiar with your design goals, so if this isn't how you'd like things done, let me know and I'd be happy to change it up :grin: 

This PR adds `JsonSchema` impls for const generic arrays, allowing both arrays with size greater than 32, as well as arrays of any size (for reference, I ran into this while trying to implement `JsonSchema` on a type in my crate that wraps a `[u8; N]`).

There's a couple of downsides:
 - this is a breaking change, since the existing impl made special exceptions for 0-length arrays, allowing schemas to generated even for 0-length arrays of types that don't implement `JsonSchema`.. AFAIK, doing this is impossible in the presence of a const-generic impl without specialization. The compromise was to export a newtype wrapper: `EmptyArray<T>`, which provides that impl. Of course, this means that downstream users who relied on `[RandomStruct; 0]: JsonSchema` will now need to replace `[RandomStruct; 0]` with `EmptyArray<RandomStruct>`. 
 - It also bumps the MSRV to 1.51 - the minimum version which supports const generics. I couldn't find an MSRV policy anywhere, so this didn't seem like a huge concern - again, happy to be corrected on this.

I'm not an expert w.r.t. json schema in general, so I guess it seems weird to me to want a schema that says: "this field expects a 0-length array of an unrepresentable type". Is this common in the wild? What's the use-case?

My first thought would actually be to not have the `EmptyArray` type at all, since that seems so "out there", but given that there's already specific tests in place checking that behaviour exists, I thought it best to check before just removing support.

Thanks :grin: 