### PR TITLE
feat(bidgecimal): use a string with numeric pattern for bigdecimal crate

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -60,6 +60,10 @@ indexmap1 = ["indexmap"]
 ui_test = []
 
 [[test]]
+name = "bigdecimal"
+required-features = ["bigdecimal"]
+
+[[test]]
 name = "chrono"
 required-features = ["chrono"]
 

--- a/schemars/src/json_schema_impls/bigdecimal.rs
+++ b/schemars/src/json_schema_impls/bigdecimal.rs
@@ -13,9 +13,23 @@ impl JsonSchema for BigDecimal {
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
         SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            string: Some(Box::new(StringValidation {
-                pattern: Some("^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$".to_string()),
+            subschemas: Some(Box::new(SubschemaValidation {
+                any_of: Some(vec![
+                    SchemaObject {
+                        instance_type: Some(InstanceType::Number.into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    SchemaObject {
+                        instance_type: Some(InstanceType::String.into()),
+                        string: Some(Box::new(StringValidation {
+                            pattern: Some("^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$".to_string()),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    }
+                    .into(),
+                ]),
                 ..Default::default()
             })),
             ..Default::default()

--- a/schemars/src/json_schema_impls/bigdecimal.rs
+++ b/schemars/src/json_schema_impls/bigdecimal.rs
@@ -1,0 +1,25 @@
+use bigdecimal::BigDecimal;
+
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+
+impl JsonSchema for BigDecimal {
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        "BigDecimal".to_string()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some("^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -27,5 +27,3 @@ macro_rules! decimal_impl {
 
 #[cfg(feature = "rust_decimal")]
 decimal_impl!(rust_decimal::Decimal);
-#[cfg(feature = "bigdecimal")]
-decimal_impl!(bigdecimal::BigDecimal);

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -42,12 +42,14 @@ mod arrayvec05;
 mod arrayvec07;
 #[cfg(std_atomic)]
 mod atomic;
+#[cfg(feature = "bigdecimal")]
+mod bigdecimal;
 #[cfg(feature = "bytes")]
 mod bytes;
 #[cfg(feature = "chrono")]
 mod chrono;
 mod core;
-#[cfg(any(feature = "rust_decimal", feature = "bigdecimal"))]
+#[cfg(feature = "rust_decimal")]
 mod decimal;
 #[cfg(feature = "either")]
 mod either;

--- a/schemars/tests/bigdecimal.rs
+++ b/schemars/tests/bigdecimal.rs
@@ -1,0 +1,17 @@
+use bigdecimal::BigDecimal;
+
+use schemars::JsonSchema;
+use util::*;
+
+mod util;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+struct BigDecimalTypes {
+    bigdecimal: BigDecimal,
+}
+
+#[test]
+fn bigdecimal_types() -> TestResult {
+    test_default_generated_schema::<BigDecimalTypes>("bigdecimal")
+}

--- a/schemars/tests/expected/bigdecimal.json
+++ b/schemars/tests/expected/bigdecimal.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BigDecimalTypes",
+  "type": "object",
+  "required": [
+    "bigdecimal"
+  ],
+  "properties": {
+    "bigdecimal": {
+      "type": "string",
+      "pattern": "^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$"
+    }
+  }
+}

--- a/schemars/tests/expected/bigdecimal.json
+++ b/schemars/tests/expected/bigdecimal.json
@@ -7,8 +7,15 @@
   ],
   "properties": {
     "bigdecimal": {
-      "type": "string",
-      "pattern": "^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "pattern": "^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This will allow arbitrary precision values to be valid.

BREAKING CHANGE: the output JSON Schema for bigdecimal::BigDecimal type is now a string in addition of a number scalar.

Addresses #123 