### PR TITLE
feat: use enum values as keys for map

### DIFF
--- a/schemars/src/json_schema_impls/indexmap.rs
+++ b/schemars/src/json_schema_impls/indexmap.rs
@@ -4,5 +4,5 @@ use crate::JsonSchema;
 use indexmap::{IndexMap, IndexSet};
 use std::collections::{HashMap, HashSet};
 
-forward_impl!((<K, V: JsonSchema, H> JsonSchema for IndexMap<K, V, H>) => HashMap<K, V, H>);
+forward_impl!((<K: JsonSchema, V: JsonSchema, H> JsonSchema for IndexMap<K, V, H>) => HashMap<K, V, H>);
 forward_impl!((<T: JsonSchema, H> JsonSchema for IndexSet<T, H>) => HashSet<T, H>);

--- a/schemars/src/json_schema_impls/maps.rs
+++ b/schemars/src/json_schema_impls/maps.rs
@@ -26,11 +26,15 @@ macro_rules! map_impl {
                     let mut schemas: Vec<Schema> = vec![];
                     if let Some(values) = &schema_object.enum_values {
                         for value in values {
+                            // enum values all have quotes around them, so remove them
+                            let str_value = &value.to_string();
+                            let value = format!("{}", &str_value[1..str_value.len()-1]);
+
                             let schema = SchemaObject {
                                 instance_type: Some(InstanceType::Object.into()),
                                 object: Some(Box::new(ObjectValidation {
-                                    required: Set::from([value.to_string()]),
-                                    properties: Map::from([(value.to_string(), v_subschema.clone())]),
+                                    required: Set::from([value.clone()]),
+                                    properties: Map::from([(value, v_subschema.clone())]),
                                     ..Default::default()
                                 })),
                                 ..Default::default()


### PR DESCRIPTION
This PR fixes https://github.com/GREsau/okapi/issues/128.

When generating a schema for a `Map` with a key that is an `enum`, the generated schema only allows keys based off of the `enum` options. For example,
```rust
use schemars::{schema_for, JsonSchema};
use serde::Serialize;
use std::collections::BTreeMap;

#[derive(serde::Serialize, JsonSchema, Debug)]
struct EnumKeyStruct {
    key: BTreeMap<Thing, SomeOtherStruct>,
}

#[derive(serde::Serialize, JsonSchema, Debug)]
enum Thing {
    Option1,
    Option2,
}

#[derive(serde::Serialize, JsonSchema, Debug)]
struct SomeOtherStruct {
    key1: String,
    key2: u64,
    key3: bool,
}

fn main() {
    let schema = schema_for!(EnumKeyStruct);
    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
}
```
yields:

```JSON
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "EnumKeyStruct",
  "type": "object",
  "required": [
    "key"
  ],
  "properties": {
    "key": {
      "oneOf": [
        {
          "type": "object",
          "required": [
            "\"Option1\""
          ],
          "properties": {
            "\"Option1\"": {
              "$ref": "#/definitions/SomeOtherStruct"
            }
          }
        },
        {
          "type": "object",
          "required": [
            "\"Option2\""
          ],
          "properties": {
            "\"Option2\"": {
              "$ref": "#/definitions/SomeOtherStruct"
            }
          }
        }
      ]
    }
  },
  "definitions": {
    "SomeOtherStruct": {
      "type": "object",
      "required": [
        "key1",
        "key2",
        "key3"
      ],
      "properties": {
        "key1": {
          "type": "string"
        },
        "key2": {
          "type": "integer",
          "format": "uint64",
          "minimum": 0.0
        },
        "key3": {
          "type": "boolean"
        }
      }
    },
    "Thing": {
      "type": "string",
      "enum": [
        "Option1",
        "Option2"
      ]
    }
  }
}
```

This also maintains the original behavior for maps with non-enum keys:
<details>
<summary>BTreeMap&lt;String, String&gt;</summary>

#### Code

```rust
use schemars::{schema_for, JsonSchema};
use serde::Serialize;
use std::collections::BTreeMap;

#[derive(Serialize, JsonSchema, Debug)]
struct PlainMap {
    key: BTreeMap<String, String>,
}

fn main() {
    let schema = schema_for!(PlainMap);
    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
}
```
#### Output
```JSON
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "PlainMap",
  "type": "object",
  "required": [
    "key"
  ],
  "properties": {
    "key": {
      "type": "object",
      "additionalProperties": {
        "type": "string"
      }
    }
  }
}
```
</details>

<details>
<summary>BTreeMap&lt;SomeStruct, String&gt;</summary>

#### Code

```rust
use schemars::{schema_for, JsonSchema};
use serde::Serialize;
use std::collections::BTreeMap;

#[derive(serde::Serialize, JsonSchema, Debug)]
struct SomeStruct {
    key: BTreeMap<SomeOtherStruct, String>,
}

#[derive(serde::Serialize, JsonSchema, Debug)]
struct SomeOtherStruct {
    key1: String,
    key2: u64,
    key3: bool,
}
fn main() {
    let schema = schema_for!(SomeOtherStruct);
    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
}
```
#### Output
```JSON
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "SomeOtherStruct",
  "type": "object",
  "required": [
    "key1",
    "key2",
    "key3"
  ],
  "properties": {
    "key1": {
      "type": "string"
    },
    "key2": {
      "type": "integer",
      "format": "uint64",
      "minimum": 0.0
    },
    "key3": {
      "type": "boolean"
    }
  }
}
```
</details>