### PR TITLE
Support bigdecimal 0.4

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -31,7 +31,8 @@ arrayvec07 = { version = "0.7", default-features = false, optional = true, packa
 url = { version = "2.0", default-features = false, optional = true }
 bytes = { version = "1.0", optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
-bigdecimal = { version = "0.3", default-features = false, optional = true }
+bigdecimal03 = { version = "0.3", default-features = false, optional = true, package = "bigdecimal" }
+bigdecimal04 = { version = "0.4", default-features = false, optional = true, package = "bigdecimal" }
 enumset = { version = "1.0", optional = true }
 smol_str = { version = "0.1.17", optional = true }
 semver = { version = "1.0.9", features = ["serde"], optional = true }
@@ -61,6 +62,9 @@ arrayvec = ["arrayvec05"]
 indexmap1 = ["indexmap"]
 
 raw_value = ["serde_json/raw_value"]
+# `bigdecimal` feature without version suffix is included only for back-compat - will be removed in a later version
+bigdecimal = ["bigdecimal03"]
+bigdecimal04 = ["dep:bigdecimal04"]
 
 ui_test = []
 

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -28,4 +28,6 @@ macro_rules! decimal_impl {
 #[cfg(feature = "rust_decimal")]
 decimal_impl!(rust_decimal::Decimal);
 #[cfg(feature = "bigdecimal")]
-decimal_impl!(bigdecimal::BigDecimal);
+decimal_impl!(bigdecimal03::BigDecimal);
+#[cfg(feature = "bigdecimal04")]
+decimal_impl!(bigdecimal04::BigDecimal);


### PR DESCRIPTION
I copied the approach from other similar packages (e.g. uuid 0.8 vs 1.0) to ensure backwards compatibility.