### PR TITLE
Add schema_id(), handles different types with the same name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "rust-analyzer.check.command": "clippy"
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/schemars/src/json_schema_impls/array.rs
+++ b/schemars/src/json_schema_impls/array.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 
 // Does not require T: JsonSchema.
 impl<T> JsonSchema for [T; 0] {
@@ -8,6 +9,10 @@ impl<T> JsonSchema for [T; 0] {
 
     fn schema_name() -> String {
         "EmptyArray".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("[]")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
@@ -31,6 +36,11 @@ macro_rules! array_impls {
 
                 fn schema_name() -> String {
                     format!("Array_size_{}_of_{}", $len, T::schema_name())
+                }
+
+                fn schema_id() -> Cow<'static, str> {
+                    Cow::Owned(
+                        format!("[{}; {}]", $len, T::schema_id()))
                 }
 
                 fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/chrono.rs
+++ b/schemars/src/json_schema_impls/chrono.rs
@@ -3,12 +3,17 @@ use crate::schema::*;
 use crate::JsonSchema;
 use chrono::prelude::*;
 use serde_json::json;
+use std::borrow::Cow;
 
 impl JsonSchema for Weekday {
     no_ref_schema!();
 
     fn schema_name() -> String {
         "Weekday".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("chrono::Weekday")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
@@ -39,6 +44,10 @@ macro_rules! formatted_string_impl {
 
             fn schema_name() -> String {
                 stringify!($ty).to_owned()
+            }
+
+            fn schema_id() -> Cow<'static, str>  {
+                Cow::Borrowed(stringify!(chrono::$ty))
             }
 
             fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/core.rs
+++ b/schemars/src/json_schema_impls/core.rs
@@ -2,6 +2,7 @@ use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
 use serde_json::json;
+use std::borrow::Cow;
 use std::ops::{Bound, Range, RangeInclusive};
 
 impl<T: JsonSchema> JsonSchema for Option<T> {
@@ -9,6 +10,10 @@ impl<T: JsonSchema> JsonSchema for Option<T> {
 
     fn schema_name() -> String {
         format!("Nullable_{}", T::schema_name())
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(format!("Option<{}>", T::schema_id()))
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
@@ -69,6 +74,10 @@ impl<T: JsonSchema, E: JsonSchema> JsonSchema for Result<T, E> {
         format!("Result_of_{}_or_{}", T::schema_name(), E::schema_name())
     }
 
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(format!("Result<{}, {}>", T::schema_id(), E::schema_id()))
+    }
+
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
         let mut ok_schema = SchemaObject {
             instance_type: Some(InstanceType::Object.into()),
@@ -97,6 +106,10 @@ impl<T: JsonSchema, E: JsonSchema> JsonSchema for Result<T, E> {
 impl<T: JsonSchema> JsonSchema for Bound<T> {
     fn schema_name() -> String {
         format!("Bound_of_{}", T::schema_name())
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(format!("Bound<{}>", T::schema_id()))
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
@@ -137,6 +150,10 @@ impl<T: JsonSchema> JsonSchema for Bound<T> {
 impl<T: JsonSchema> JsonSchema for Range<T> {
     fn schema_name() -> String {
         format!("Range_of_{}", T::schema_name())
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(format!("Range<{}>", T::schema_id()))
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 
 macro_rules! decimal_impl {
     ($type:ty) => {
@@ -12,6 +13,10 @@ macro_rules! decimal_impl {
 
             fn schema_name() -> String {
                 $name.to_owned()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed($name)
             }
 
             fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/either.rs
+++ b/schemars/src/json_schema_impls/either.rs
@@ -2,12 +2,17 @@ use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
 use either::Either;
+use std::borrow::Cow;
 
 impl<L: JsonSchema, R: JsonSchema> JsonSchema for Either<L, R> {
     no_ref_schema!();
 
     fn schema_name() -> String {
         format!("Either_{}_or_{}", L::schema_name(), R::schema_name())
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(format!("Either<{}, {}>", L::schema_id(), R::schema_id()))
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/either.rs
+++ b/schemars/src/json_schema_impls/either.rs
@@ -12,7 +12,11 @@ impl<L: JsonSchema, R: JsonSchema> JsonSchema for Either<L, R> {
     }
 
     fn schema_id() -> Cow<'static, str> {
-        Cow::Owned(format!("Either<{}, {}>", L::schema_id(), R::schema_id()))
+        Cow::Owned(format!(
+            "either::Either<{}, {}>",
+            L::schema_id(),
+            R::schema_id()
+        ))
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/ffi.rs
+++ b/schemars/src/json_schema_impls/ffi.rs
@@ -1,11 +1,16 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 
 impl JsonSchema for OsString {
     fn schema_name() -> String {
         "OsString".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("std::ffi::OsString")
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/maps.rs
+++ b/schemars/src/json_schema_impls/maps.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 
 macro_rules! map_impl {
     ($($desc:tt)+) => {
@@ -12,6 +13,10 @@ macro_rules! map_impl {
 
             fn schema_name() -> String {
                 format!("Map_of_{}", V::schema_name())
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Owned(format!("Map<{}>", V::schema_id()))
             }
 
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -17,6 +17,10 @@ macro_rules! forward_impl {
                 <$target>::schema_name()
             }
 
+            fn schema_id() -> std::borrow::Cow<'static, str> {
+                <$target>::schema_id()
+            }
+
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {
                 <$target>::json_schema(gen)
             }

--- a/schemars/src/json_schema_impls/nonzero_signed.rs
+++ b/schemars/src/json_schema_impls/nonzero_signed.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use std::num::*;
 
 macro_rules! nonzero_unsigned_impl {
@@ -10,6 +11,10 @@ macro_rules! nonzero_unsigned_impl {
 
             fn schema_name() -> String {
                 stringify!($type).to_owned()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed(stringify!(std::num::$type))
             }
 
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/nonzero_unsigned.rs
+++ b/schemars/src/json_schema_impls/nonzero_unsigned.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use std::num::*;
 
 macro_rules! nonzero_unsigned_impl {
@@ -10,6 +11,10 @@ macro_rules! nonzero_unsigned_impl {
 
             fn schema_name() -> String {
                 stringify!($type).to_owned()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed(stringify!(std::num::$type))
             }
 
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/primitives.rs
+++ b/schemars/src/json_schema_impls/primitives.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::path::{Path, PathBuf};
 
@@ -17,6 +18,10 @@ macro_rules! simple_impl {
 
             fn schema_name() -> String {
                 $name.to_owned()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed($name)
             }
 
             fn json_schema(_: &mut SchemaGenerator) -> Schema {
@@ -64,6 +69,10 @@ macro_rules! unsigned_impl {
                 $format.to_owned()
             }
 
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed($format)
+            }
+
             fn json_schema(_: &mut SchemaGenerator) -> Schema {
                 let mut schema = SchemaObject {
                     instance_type: Some(InstanceType::$instance_type.into()),
@@ -89,6 +98,10 @@ impl JsonSchema for char {
 
     fn schema_name() -> String {
         "Character".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("char")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/semver.rs
+++ b/schemars/src/json_schema_impls/semver.rs
@@ -2,12 +2,17 @@ use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
 use semver::Version;
+use std::borrow::Cow;
 
 impl JsonSchema for Version {
     no_ref_schema!();
 
     fn schema_name() -> String {
         "Version".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("semver::Version")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/sequences.rs
+++ b/schemars/src/json_schema_impls/sequences.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 
 macro_rules! seq_impl {
     ($($desc:tt)+) => {
@@ -12,6 +13,11 @@ macro_rules! seq_impl {
 
             fn schema_name() -> String {
                 format!("Array_of_{}", T::schema_name())
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Owned(
+                    format!("[{}]", T::schema_id()))
             }
 
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {
@@ -39,6 +45,11 @@ macro_rules! set_impl {
 
             fn schema_name() -> String {
                 format!("Set_of_{}", T::schema_name())
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Owned(
+                    format!("Set<{}>", T::schema_id()))
             }
 
             fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/serdejson.rs
+++ b/schemars/src/json_schema_impls/serdejson.rs
@@ -2,6 +2,7 @@ use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
 use serde_json::{Map, Number, Value};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 impl JsonSchema for Value {
@@ -9,6 +10,10 @@ impl JsonSchema for Value {
 
     fn schema_name() -> String {
         "AnyValue".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("AnyValue")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {
@@ -23,6 +28,10 @@ impl JsonSchema for Number {
 
     fn schema_name() -> String {
         "Number".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("Number")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/time.rs
+++ b/schemars/src/json_schema_impls/time.rs
@@ -1,11 +1,16 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use std::time::{Duration, SystemTime};
 
 impl JsonSchema for Duration {
     fn schema_name() -> String {
         "Duration".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("std::time::Duration")
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
@@ -27,6 +32,10 @@ impl JsonSchema for Duration {
 impl JsonSchema for SystemTime {
     fn schema_name() -> String {
         "SystemTime".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("std::time::SystemTime")
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/tuple.rs
+++ b/schemars/src/json_schema_impls/tuple.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 
 macro_rules! tuple_impls {
     ($($len:expr => ($($name:ident)+))+) => {
@@ -12,6 +13,14 @@ macro_rules! tuple_impls {
                     let mut name = "Tuple_of_".to_owned();
                     name.push_str(&[$($name::schema_name()),+].join("_and_"));
                     name
+                }
+
+                fn schema_id() -> Cow<'static, str> {
+                    let mut id = "(".to_owned();
+                    id.push_str(&[$($name::schema_id()),+].join(","));
+                    id.push(')');
+
+                    Cow::Owned(id)
                 }
 
                 fn json_schema(gen: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/url.rs
+++ b/schemars/src/json_schema_impls/url.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use url::Url;
 
 impl JsonSchema for Url {
@@ -8,6 +9,10 @@ impl JsonSchema for Url {
 
     fn schema_name() -> String {
         "Url".to_owned()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("url::Url")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/uuid08.rs
+++ b/schemars/src/json_schema_impls/uuid08.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use uuid08::Uuid;
 
 impl JsonSchema for Uuid {
@@ -8,6 +9,10 @@ impl JsonSchema for Uuid {
 
     fn schema_name() -> String {
         "Uuid".to_string()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("uuid::Uuid")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/json_schema_impls/uuid1.rs
+++ b/schemars/src/json_schema_impls/uuid1.rs
@@ -1,6 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
+use std::borrow::Cow;
 use uuid1::Uuid;
 
 impl JsonSchema for Uuid {
@@ -8,6 +9,10 @@ impl JsonSchema for Uuid {
 
     fn schema_name() -> String {
         "Uuid".to_string()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Borrowed("uuid::Uuid")
     }
 
     fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -41,6 +41,8 @@ pub mod visit;
 
 #[cfg(feature = "schemars_derive")]
 extern crate schemars_derive;
+use std::borrow::Cow;
+
 #[cfg(feature = "schemars_derive")]
 pub use schemars_derive::*;
 
@@ -82,6 +84,11 @@ pub trait JsonSchema {
     ///
     /// This is used as the title for root schemas, and the key within the root's `definitions` property for subschemas.
     fn schema_name() -> String;
+
+    // TODO document
+    fn schema_id() -> Cow<'static, str> {
+        Cow::Owned(Self::schema_name())
+    }
 
     /// Generates a JSON Schema for this type.
     ///

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -58,7 +58,8 @@ use schema::Schema;
 ///
 /// This can also be automatically derived on most custom types with `#[derive(JsonSchema)]`.
 ///
-/// # Example
+/// # Examples
+/// Deriving an implementation:
 /// ```
 /// use schemars::{schema_for, JsonSchema};
 ///
@@ -69,6 +70,64 @@ use schema::Schema;
 ///
 /// let my_schema = schema_for!(MyStruct);
 /// ```
+///
+/// When manually implementing `JsonSchema`, as well as determining an appropriate schema,
+/// you will need to determine an appropriate name and ID for the type.
+/// For non-generic types, the type name/path are suitable for this:
+/// ```
+/// use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+/// use std::borrow::Cow;
+///
+/// struct NonGenericType;
+///
+/// impl JsonSchema for NonGenericType {
+///     fn schema_name() -> String {
+///         // Exclude the module path to make the name in generated schemas clearer.
+///         "NonGenericType".to_owned()
+///     }
+///
+///     fn schema_id() -> Cow<'static, str> {
+///         // Include the module, in case a type with the same name is in another module/crate
+///         Cow::Borrowed(concat!(module_path!(), "::NonGenericType"))
+///     }
+///
+///     fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+///         todo!()
+///     }
+/// }
+///
+/// assert_eq!(NonGenericType::schema_id(), <&mut NonGenericType>::schema_id());
+/// ```
+///
+/// But generic type parameters which may affect the generated schema should typically be included in the name/ID:
+/// ```
+/// use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+/// use std::{borrow::Cow, marker::PhantomData};
+///
+/// struct GenericType<T>(PhantomData<T>);
+///
+/// impl<T: JsonSchema> JsonSchema for GenericType<T> {
+///     fn schema_name() -> String {
+///         format!("GenericType_{}", T::schema_name())
+///     }
+///
+///     fn schema_id() -> Cow<'static, str> {
+///         Cow::Owned(format!(
+///             "{}::GenericType<{}>",
+///             module_path!(),
+///             T::schema_id()
+///         ))
+///     }
+///
+///     fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+///         todo!()
+///     }
+/// }
+///
+/// assert_eq!(<GenericType<i32>>::schema_id(), <&mut GenericType<&i32>>::schema_id());
+/// ```
+///
+
 pub trait JsonSchema {
     /// Whether JSON Schemas generated for this type should be re-used where possible using the `$ref` keyword.
     ///
@@ -85,7 +144,13 @@ pub trait JsonSchema {
     /// This is used as the title for root schemas, and the key within the root's `definitions` property for subschemas.
     fn schema_name() -> String;
 
-    // TODO document
+    /// Returns a string that uniquely identifies the schema produced by this type.
+    ///
+    /// This does not have to be a human-readable string, and the value will not itself be included in generated schemas.
+    /// If two types produce different schemas, then they **must** have different `schema_id()`s,
+    /// but two types that produce identical schemas should *ideally* have the same `schema_id()`.
+    ///
+    /// The default implementation returns the same value as `schema_name()`.
     fn schema_id() -> Cow<'static, str> {
         Cow::Owned(Self::schema_name())
     }

--- a/schemars/tests/expected/same_name.json
+++ b/schemars/tests/expected/same_name.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config2",
+  "type": "object",
+  "required": [
+    "a_cfg",
+    "b_cfg"
+  ],
+  "properties": {
+    "a_cfg": {
+      "$ref": "#/definitions/Config"
+    },
+    "b_cfg": {
+      "$ref": "#/definitions/Config2"
+    }
+  },
+  "definitions": {
+    "Config": {
+      "type": "object",
+      "required": [
+        "test"
+      ],
+      "properties": {
+        "test": {
+          "type": "string"
+        }
+      }
+    },
+    "Config2": {
+      "type": "object",
+      "required": [
+        "test2"
+      ],
+      "properties": {
+        "test2": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemars/tests/same_name.rs
+++ b/schemars/tests/same_name.rs
@@ -1,0 +1,35 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+mod a {
+    use super::*;
+
+    #[allow(dead_code)]
+    #[derive(JsonSchema)]
+    pub struct Config {
+        test: String,
+    }
+}
+
+mod b {
+    use super::*;
+
+    #[allow(dead_code)]
+    #[derive(JsonSchema)]
+    pub struct Config {
+        test2: String,
+    }
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct Config2 {
+    a_cfg: a::Config,
+    b_cfg: b::Config,
+}
+
+#[test]
+fn same_name() -> TestResult {
+    test_default_generated_schema::<Config2>("same_name")
+}

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -67,6 +67,10 @@ fn derive_json_schema(
                         <#ty as schemars::JsonSchema>::schema_name()
                     }
 
+                    fn schema_id() -> std::borrow::Cow<'static, str> {
+                        <#ty as schemars::JsonSchema>::schema_id()
+                    }
+
                     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
                         <#ty as schemars::JsonSchema>::json_schema(gen)
                     }
@@ -98,27 +102,66 @@ fn derive_json_schema(
     let const_params: Vec<_> = cont.generics.const_params().map(|c| &c.ident).collect();
     let params: Vec<_> = type_params.iter().chain(const_params.iter()).collect();
 
-    let schema_name = if params.is_empty()
+    let (schema_name, schema_id) = if params.is_empty()
         || (cont.attrs.is_renamed && !schema_base_name.contains('{'))
     {
-        quote! {
-            #schema_base_name.to_owned()
-        }
+        (
+            quote! {
+                #schema_base_name.to_owned()
+            },
+            quote! {
+                std::borrow::Cow::Borrowed(std::concat!(
+                    std::module_path!(),
+                    "::",
+                    #schema_base_name
+                ))
+            },
+        )
     } else if cont.attrs.is_renamed {
         let mut schema_name_fmt = schema_base_name;
         for tp in &params {
             schema_name_fmt.push_str(&format!("{{{}:.0}}", tp));
         }
-        quote! {
-            format!(#schema_name_fmt #(,#type_params=#type_params::schema_name())* #(,#const_params=#const_params)*)
-        }
+        (
+            quote! {
+                format!(#schema_name_fmt #(,#type_params=#type_params::schema_name())* #(,#const_params=#const_params)*)
+            },
+            quote! {
+                std::borrow::Cow::Owned(
+                    format!(
+                        std::concat!(
+                            std::module_path!(),
+                            "::",
+                            #schema_name_fmt
+                        )
+                        #(,#type_params=#type_params::schema_id())*
+                        #(,#const_params=#const_params)*
+                    )
+                )
+            },
+        )
     } else {
         let mut schema_name_fmt = schema_base_name;
         schema_name_fmt.push_str("_for_{}");
         schema_name_fmt.push_str(&"_and_{}".repeat(params.len() - 1));
-        quote! {
-            format!(#schema_name_fmt #(,#type_params::schema_name())* #(,#const_params)*)
-        }
+        (
+            quote! {
+                format!(#schema_name_fmt #(,#type_params::schema_name())* #(,#const_params)*)
+            },
+            quote! {
+                std::borrow::Cow::Owned(
+                    format!(
+                        std::concat!(
+                            std::module_path!(),
+                            "::",
+                            #schema_name_fmt
+                        )
+                        #(,#type_params::schema_id())*
+                        #(,#const_params)*
+                    )
+                )
+            },
+        )
     };
 
     let schema_expr = if repr {
@@ -136,6 +179,10 @@ fn derive_json_schema(
             impl #impl_generics schemars::JsonSchema for #type_name #ty_generics #where_clause {
                 fn schema_name() -> std::string::String {
                     #schema_name
+                }
+
+                fn schema_id() -> std::borrow::Cow<'static, str> {
+                    #schema_id
                 }
 
                 fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -109,6 +109,15 @@ fn type_for_schema(with_attr: &WithAttr) -> (syn::Type, Option<TokenStream>) {
                         #fn_name.to_string()
                     }
 
+                    fn schema_id() -> std::borrow::Cow<'static, str> {
+                        std::borrow::Cow::Borrowed(std::concat!(
+                            "_SchemarsSchemaWithFunction/"
+                            std::module_path!(),
+                            "/",
+                            #fn_name
+                        ))
+                    }
+
                     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
                         #fun(gen)
                     }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -111,7 +111,7 @@ fn type_for_schema(with_attr: &WithAttr) -> (syn::Type, Option<TokenStream>) {
 
                     fn schema_id() -> std::borrow::Cow<'static, str> {
                         std::borrow::Cow::Borrowed(std::concat!(
-                            "_SchemarsSchemaWithFunction/"
+                            "_SchemarsSchemaWithFunction/",
                             std::module_path!(),
                             "/",
                             #fn_name


### PR DESCRIPTION
Fixes #62 by implementing https://github.com/GREsau/schemars/issues/62#issuecomment-826388168

Schemars currently differentiates between types using the `JsonSchema::schema_name()` function, which typically returns the type name (excluding the module path). This PR updates the schema generator to differentiate between types using the new function `JsonSchema::schema_id()`, which is similar, but includes the type's module path. This leaves `schema_name()` returning a clean, human-readable "friendly" name mostly free of rust details (e.g. being unaffected by module renames).

`schema_id()` has a default implementation (which delegates to `schema_name()`), so this should be a non-breaking change.

Because a vast majority of types have a statically-determined id (and name), `schema_id()` returns a `Cow<'static, str>` instead of a `String` - in future, I'd like to change `schema_name()` to return a `Cow` for the same reason, but that will be a breaking change so is not being done in this PR. The main reason an implementation would return a `Cow::Owned(String)` would be a generic type, e.g. `Vec<T>`, where the return value of `schema_id()` (and of `schema_name()`) depends on that of `T`.

In many cases, the return value of `T::schema_id()` will be identical to that of `std::any::type_name::<T>()`, so ideally we could just use that - unfortunately `type_name()` is unsuitable here for two reasons:
1. the output of `type_name()` may change in a future rust version e.g. by excluding the module path, or including lifetime specifiers
2. some distinct rust types have equivalent schemas, so should have identical return values of `schema_id()`, e.g. `String`/`str`/`&str`, but these will all have different return values of `type_name()`

Still to do:
- Update docs
  - doc comment for `schema_id()` ✅ 
  - web docs - will be done in a separate change
- implement `schema_id()` appropriately for optional dependencies ✅ 
- add tests ✅ 
