### PR TITLE
Fix schemas for bigdecimal/rust_decimal

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -120,5 +120,9 @@ required-features = ["smol_str"]
 name = "semver"
 required-features = ["semver"]
 
+[[test]]
+name = "decimal"
+required-features = ["rust_decimal", "bigdecimal"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -4,19 +4,20 @@ use crate::JsonSchema;
 
 macro_rules! decimal_impl {
     ($type:ty) => {
-        decimal_impl!($type => Number, "Number");
-    };
-    ($type:ty => $instance_type:ident, $name:expr) => {
         impl JsonSchema for $type {
             no_ref_schema!();
 
             fn schema_name() -> String {
-                $name.to_owned()
+                "Decimal".to_owned()
             }
 
             fn json_schema(_: &mut SchemaGenerator) -> Schema {
                 SchemaObject {
-                    instance_type: Some(InstanceType::$instance_type.into()),
+                    instance_type: Some(InstanceType::String.into()),
+                    string: Some(Box::new(StringValidation {
+                        pattern: Some(r"^-?[0-9]+(\.[0-9]+)?$".to_owned()),
+                        ..Default::default()
+                    })),
                     ..Default::default()
                 }
                 .into()

--- a/schemars/tests/decimal.rs
+++ b/schemars/tests/decimal.rs
@@ -1,0 +1,12 @@
+mod util;
+use util::*;
+
+#[test]
+fn rust_decimal() -> TestResult {
+    test_default_generated_schema::<rust_decimal::Decimal>("rust_decimal")
+}
+
+#[test]
+fn bigdecimal() -> TestResult {
+    test_default_generated_schema::<bigdecimal::BigDecimal>("bigdecimal")
+}

--- a/schemars/tests/expected/bigdecimal.json
+++ b/schemars/tests/expected/bigdecimal.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Decimal",
+  "type": "string",
+  "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+}

--- a/schemars/tests/expected/rust_decimal.json
+++ b/schemars/tests/expected/rust_decimal.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Decimal",
+  "type": "string",
+  "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+}


### PR DESCRIPTION
Both of these crates serialise decimals as strings, not as plain numbers.

Half-fixes #123 - there's not yet a good way to handle different schemas for serialization vs deserialization, so this PR just makes the schemas match how these types are serialized (numeric strings).