### PR TITLE
Add support for multiple enum flatten

### DIFF
--- a/schemars/tests/expected/multiple_enum_flatten.json
+++ b/schemars/tests/expected/multiple_enum_flatten.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Flat",
+  "allOf": [
+    {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "B"
+          ],
+          "properties": {
+            "B": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "S"
+          ],
+          "properties": {
+            "S": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "required": [
+        "f"
+      ],
+      "properties": {
+        "f": {
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "U"
+          ],
+          "properties": {
+            "U": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "F"
+          ],
+          "properties": {
+            "F": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ]
+}

--- a/schemars/tests/multiple_enum_flatten.rs
+++ b/schemars/tests/multiple_enum_flatten.rs
@@ -1,0 +1,33 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "Flat")]
+struct Flat {
+    f: f32,
+    #[schemars(flatten)]
+    e1: Enum1,
+    #[schemars(flatten)]
+    e2: Enum2,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum1 {
+    B(bool),
+    S(String),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum2 {
+    U(u32),
+    F(f64)
+}
+
+#[test]
+fn test_flat_schema() -> TestResult {
+    test_default_generated_schema::<Flat>("multiple_enum_flatten")
+}


### PR DESCRIPTION
Fix #165.

Use `all_of` when flattening multiple `subschemas`.

There is still a limitation when flattening required enum. We lose the information that the field is required. This is not caused by this PR. This could be fix in another PR.