### PR TITLE
Add impl for smol_str v0.2

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -34,7 +34,8 @@ rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal03 = { version = "0.3", default-features = false, optional = true, package = "bigdecimal" }
 bigdecimal04 = { version = "0.4", default-features = false, optional = true, package = "bigdecimal" }
 enumset = { version = "1.0", optional = true }
-smol_str = { version = "0.1.17", optional = true }
+smol_str01 = { package = "smol_str", version = "0.1.17", optional = true }
+smol_str02 = { package = "smol_str", version = "0.2.1", optional = true }
 semver = { version = "1.0.9", features = ["serde"], optional = true }
 
 [dev-dependencies]
@@ -60,6 +61,8 @@ uuid = ["uuid08"]
 # `arrayvec` feature without version suffix is included only for back-compat - will be removed in a later version
 arrayvec = ["arrayvec05"]
 indexmap1 = ["indexmap"]
+# `smol_str` feature without version suffix is included only for back-compat - will be removed in a later version
+smol_str = ["smol_str01"]
 
 raw_value = ["serde_json/raw_value"]
 # `bigdecimal` feature without version suffix is included only for back-compat - will be removed in a later version
@@ -116,8 +119,12 @@ name = "enumset"
 required-features = ["enumset"]
 
 [[test]]
-name = "smol_str"
-required-features = ["smol_str"]
+name = "smol_str01"
+required-features = ["smol_str01"]
+
+[[test]]
+name = "smol_str02"
+required-features = ["smol_str02"]
 
 [[test]]
 name = "semver"

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -76,8 +76,10 @@ mod sequences;
 mod serdejson;
 #[cfg(feature = "smallvec")]
 mod smallvec;
-#[cfg(feature = "smol_str")]
-mod smol_str;
+#[cfg(feature = "smol_str01")]
+mod smol_str01;
+#[cfg(feature = "smol_str02")]
+mod smol_str02;
 mod time;
 mod tuple;
 #[cfg(feature = "url")]

--- a/schemars/src/json_schema_impls/smol_str01.rs
+++ b/schemars/src/json_schema_impls/smol_str01.rs
@@ -1,0 +1,6 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use smol_str01::SmolStr;
+
+forward_impl!(SmolStr => String);

--- a/schemars/src/json_schema_impls/smol_str02.rs
+++ b/schemars/src/json_schema_impls/smol_str02.rs
@@ -1,6 +1,6 @@
 use crate::gen::SchemaGenerator;
 use crate::schema::*;
 use crate::JsonSchema;
-use smol_str::SmolStr;
+use smol_str02::SmolStr;
 
 forward_impl!(SmolStr => String);

--- a/schemars/tests/expected/smol_str01.json
+++ b/schemars/tests/expected/smol_str01.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "String",
+  "type": "string"
+}

--- a/schemars/tests/expected/smol_str02.json
+++ b/schemars/tests/expected/smol_str02.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "String",
+  "type": "string"
+}

--- a/schemars/tests/smol_str.rs
+++ b/schemars/tests/smol_str.rs
@@ -1,8 +1,0 @@
-mod util;
-use smol_str::SmolStr;
-use util::*;
-
-#[test]
-fn smol_str() -> TestResult {
-    test_default_generated_schema::<SmolStr>("smol_str")
-}

--- a/schemars/tests/smol_str01.rs
+++ b/schemars/tests/smol_str01.rs
@@ -1,0 +1,8 @@
+mod util;
+use smol_str01::SmolStr;
+use util::*;
+
+#[test]
+fn smol_str01() -> TestResult {
+    test_default_generated_schema::<SmolStr>("smol_str01")
+}

--- a/schemars/tests/smol_str02.rs
+++ b/schemars/tests/smol_str02.rs
@@ -1,0 +1,8 @@
+mod util;
+use smol_str02::SmolStr;
+use util::*;
+
+#[test]
+fn smol_str02() -> TestResult {
+    test_default_generated_schema::<SmolStr>("smol_str02")
+}


### PR DESCRIPTION
This PR takes the same strategy as the `arrayvec` and `uuid` crates and implements features with the names `smol_str01` and `smol_str02` with the `smol_str` feature enabling the `smol_str01` feature for compatibility reasons.