### PR TITLE
Fix multiple flatten with all_of

### DIFF
--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -12,9 +12,66 @@ impl Schema {
         } else if is_null_type(&other) {
             return self;
         }
-        let s1: SchemaObject = self.into();
-        let s2: SchemaObject = other.into();
-        Schema::Object(s1.merge(s2))
+        let mut s1: SchemaObject = self.into();
+        let mut s2: SchemaObject = other.into();
+
+        let s1_subschemas = &mut s1.subschemas;
+        let s1_all_of = s1_subschemas.as_mut().and_then(|sub_sch| sub_sch.all_of.as_mut());
+        let s2_subschemas = &mut s2.subschemas;
+        let s2_all_of = s2_subschemas.as_mut().and_then(|sub_sch| sub_sch.all_of.as_mut());
+
+        match (s1_all_of, s2_all_of) {
+            (Some(s1_all_of), Some(s2_all_of)) => {
+                let mut s1_all_of = std::mem::take(s1_all_of);
+                s1_all_of.append(s2_all_of);
+                Schema::Object(SchemaObject {
+                    subschemas: Some(Box::new(SubschemaValidation {
+                        all_of: Some(s1_all_of),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            }
+            (Some(s1_all_of), None) => {
+                let mut s1_all_of = std::mem::take(s1_all_of);
+                s1_all_of.push(Schema::Object(s2));
+                Schema::Object(SchemaObject {
+                    subschemas: Some(Box::new(SubschemaValidation {
+                        all_of: Some(s1_all_of),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            }
+            (None, Some(s2_all_of)) => {
+                let mut s2_all_of = std::mem::take(s2_all_of);
+                s2_all_of.push(Schema::Object(s1));
+                Schema::Object(SchemaObject {
+                    subschemas: Some(Box::new(SubschemaValidation {
+                        all_of: Some(s2_all_of),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            }
+            (None, None) => {
+                match (s1_subschemas.is_some(), s2_subschemas.is_some()) {
+                    (true, true) => Schema::Object(SchemaObject {
+                        subschemas: Some(Box::new(SubschemaValidation {
+                            all_of: Some(vec![
+                                Schema::Object(s1),
+                                Schema::Object(s2),
+                            ]),
+                            ..Default::default()
+                        })),
+                        ..Default::default()
+                    }),
+                    (true, false) |
+                    (false, true) |
+                    (false, false) => Schema::Object(s1.merge(s2)),
+                }
+            }
+        }
     }
 }
 

--- a/schemars/tests/expected/multiple_enum_flatten.json
+++ b/schemars/tests/expected/multiple_enum_flatten.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Flat",
+  "allOf": [
+    {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "B"
+          ],
+          "properties": {
+            "B": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "S"
+          ],
+          "properties": {
+            "S": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "required": [
+        "f"
+      ],
+      "properties": {
+        "f": {
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "U"
+          ],
+          "properties": {
+            "U": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "F"
+          ],
+          "properties": {
+            "F": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ]
+}

--- a/schemars/tests/multiple_enum_flatten.rs
+++ b/schemars/tests/multiple_enum_flatten.rs
@@ -1,0 +1,33 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "Flat")]
+struct Flat {
+  f: f32,
+  #[schemars(flatten)]
+  e1: Enum1,
+  #[schemars(flatten)]
+  e2: Enum2,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum1 {
+  B(bool),
+  S(String),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum2 {
+  U(u32),
+  F(f64)
+}
+
+#[test]
+fn test_flat_schema() -> TestResult {
+  test_default_generated_schema::<Flat>("multiple_enum_flatten")
+}


### PR DESCRIPTION
Fix https://github.com/GREsau/schemars/issues/165.

Use all_of when flattening multiple subschemas.

There is still a limitation when flattening required enum. We lose the information that the field is required. This is not caused by this PR. This could be fix in another PR.

We use this fix in [apistos](https://github.com/netwo-io/apistos).