### PR TITLE
simplify the code generated for unit enums

### DIFF
--- a/schemars_derive/src/metadata.rs
+++ b/schemars_derive/src/metadata.rs
@@ -17,10 +17,7 @@ impl<'a> SchemaMetadata<'a> {
         if !setters.is_empty() {
             *schema_expr = quote! {{
                 let schema = #schema_expr;
-                schemars::_private::apply_metadata(schema, schemars::schema::Metadata {
-                    #(#setters)*
-                    ..Default::default()
-                })
+                schema #(#setters)*
             }}
         }
     }
@@ -30,29 +27,29 @@ impl<'a> SchemaMetadata<'a> {
 
         if let Some(title) = &self.title {
             setters.push(quote! {
-                title: Some(#title.to_owned()),
+                .with_title(#title)
             });
         }
         if let Some(description) = &self.description {
             setters.push(quote! {
-                description: Some(#description.to_owned()),
+                .with_description(#description)
             });
         }
 
         if self.deprecated {
             setters.push(quote! {
-                deprecated: true,
+                .with_deprecated(true)
             });
         }
 
         if self.read_only {
             setters.push(quote! {
-                read_only: true,
+                .with_read_only(true)
             });
         }
         if self.write_only {
             setters.push(quote! {
-                write_only: true,
+                .with_write_only(true)
             });
         }
 
@@ -63,13 +60,13 @@ impl<'a> SchemaMetadata<'a> {
                 }
             });
             setters.push(quote! {
-                examples: vec![#(#examples),*].into_iter().flatten().collect(),
+                .with_examples([#(#examples),*].into_iter().flatten())
             });
         }
 
         if let Some(default) = &self.default {
             setters.push(quote! {
-                default: #default.and_then(|d| schemars::_schemars_maybe_to_value!(d)),
+                .with_default(#default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
             });
         }
 

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -162,7 +162,7 @@ fn expr_for_external_tagged_enum<'a>(
     let unit_names = unit_variants.iter().map(|v| v.name());
     let unit_schema = schema_object(quote! {
         instance_type: Some(schemars::schema::InstanceType::String.into()),
-        enum_values: Some(vec![#(#unit_names.into()),*]),
+        enum_values: Some([#(#unit_names),*].into_iter().map(|v| v.into()).collect()),
     });
 
     if complex_variants.is_empty() {
@@ -178,10 +178,9 @@ fn expr_for_external_tagged_enum<'a>(
         let name = variant.name();
 
         let mut schema_expr = if variant.is_unit() && variant.attrs.with.is_none() {
-            schema_object(quote! {
-                instance_type: Some(schemars::schema::InstanceType::String.into()),
-                enum_values: Some(vec![#name.into()]),
-            })
+            quote! {
+                schemars::schema::Schema::new_unit_enum(#name)
+            }
         } else {
             let sub_schema = expr_for_untagged_enum_variant(variant, deny_unknown_fields);
             schema_object(quote! {


### PR DESCRIPTION
Partial solution for https://github.com/GREsau/schemars/issues/246

- replace the manual construction of `Schema::Object` with a helper method
- replace metadata setting with a function call per-metadata

Taking the enum from https://github.com/adamchalmers/rust-problems/blob/achalmers/schemars-llvm-lines/src/lib.rs and running `cargo rustc -- -Z unpretty=mir | wc -l` it goes from 165725 lines of MIR to 4871 (removing the serde derives from the linked code)

The per-variant generate code goes from:
```
{
    let schema = schemars::schema::Schema::Object(schemars::schema::SchemaObject {
        instance_type: Some(
            schemars::schema::InstanceType::String.into(),
        ),
        enum_values: Some(
            <[_]>::into_vec(
                #[rustc_box]
                ::alloc::boxed::Box::new(["Af".into()]),
            ),
        ),
        ..Default::default()
    });
    schemars::_private::apply_metadata(
        schema,
        schemars::schema::Metadata {
            description: Some("Afghanistan".to_owned()),
            ..Default::default()
        },
    )
},
```

to:

```rust
{
    let schema = schemars::schema::Schema::Object(
        schemars::schema::SchemaObject::new_unit_enum("Af"),
    );
    schema.with_description("Afghanistan")
},
```

I still have a [crate](https://github.com/demostf/parser) that takes ~forever to generate the schema for so there are still plenty of room for improvement.