### PR TITLE
Update to syn 2.0, and serde_derive_internals 0.29

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -21,7 +21,9 @@ dyn-clone = "1.0"
 
 chrono = { version = "0.4", default-features = false, optional = true }
 indexmap = { version = "1.2", features = ["serde-1"], optional = true }
-indexmap2 = { version = "2.0", features = ["serde"], optional = true, package = "indexmap" }
+indexmap2 = { version = "2.0", features = [
+    "serde",
+], optional = true, package = "indexmap" }
 either = { version = "1.3", default-features = false, optional = true }
 uuid08 = { version = "0.8", default-features = false, optional = true, package = "uuid" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }

--- a/schemars/tests/ui/invalid_validation_attrs.stderr
+++ b/schemars/tests/ui/invalid_validation_attrs.stderr
@@ -1,59 +1,59 @@
 error: expected validate regex attribute to be a string: `regex = "..."`
- --> $DIR/invalid_validation_attrs.rs:4:39
+ --> tests/ui/invalid_validation_attrs.rs:4:39
   |
 4 | pub struct Struct1(#[validate(regex = 0, foo, length(min = 1, equal = 2, bar))] String);
   |                                       ^
 
 error: unknown schemars attribute `foo`
- --> $DIR/invalid_validation_attrs.rs:7:42
+ --> tests/ui/invalid_validation_attrs.rs:7:42
   |
 7 | pub struct Struct2(#[schemars(regex = 0, foo, length(min = 1, equal = 2, bar))] String);
   |                                          ^^^
 
 error: expected schemars regex attribute to be a string: `regex = "..."`
- --> $DIR/invalid_validation_attrs.rs:7:39
+ --> tests/ui/invalid_validation_attrs.rs:7:39
   |
 7 | pub struct Struct2(#[schemars(regex = 0, foo, length(min = 1, equal = 2, bar))] String);
   |                                       ^
 
-error: schemars attribute cannot contain both `equal` and `min`
- --> $DIR/invalid_validation_attrs.rs:7:63
+error: schemars attribute cannot contain both `min` and `equal`
+ --> tests/ui/invalid_validation_attrs.rs:7:63
   |
 7 | pub struct Struct2(#[schemars(regex = 0, foo, length(min = 1, equal = 2, bar))] String);
   |                                                               ^^^^^
 
 error: unknown item in schemars length attribute
- --> $DIR/invalid_validation_attrs.rs:7:74
+ --> tests/ui/invalid_validation_attrs.rs:7:74
   |
 7 | pub struct Struct2(#[schemars(regex = 0, foo, length(min = 1, equal = 2, bar))] String);
   |                                                                          ^^^
 
-error: schemars attribute cannot contain both `contains` and `regex`
-  --> $DIR/invalid_validation_attrs.rs:26:9
+error: schemars attribute cannot contain both `regex` and `contains`
+  --> tests/ui/invalid_validation_attrs.rs:26:9
    |
 26 |         contains = "bar",
    |         ^^^^^^^^
 
 error: duplicate schemars attribute `regex`
-  --> $DIR/invalid_validation_attrs.rs:27:9
+  --> tests/ui/invalid_validation_attrs.rs:27:9
    |
 27 |         regex(path = "baz"),
    |         ^^^^^
 
 error: schemars attribute cannot contain both `phone` and `email`
-  --> $DIR/invalid_validation_attrs.rs:29:9
+  --> tests/ui/invalid_validation_attrs.rs:29:9
    |
 29 |         email,
    |         ^^^^^
 
 error: schemars attribute cannot contain both `phone` and `url`
-  --> $DIR/invalid_validation_attrs.rs:30:9
+  --> tests/ui/invalid_validation_attrs.rs:30:9
    |
 30 |         url
    |         ^^^
 
 error[E0425]: cannot find value `foo` in this scope
-  --> $DIR/invalid_validation_attrs.rs:12:17
+  --> tests/ui/invalid_validation_attrs.rs:12:17
    |
 12 |         regex = "foo",
    |                 ^^^^^ not found in this scope

--- a/schemars/tests/validate_inner.rs
+++ b/schemars/tests/validate_inner.rs
@@ -12,7 +12,7 @@ pub struct Struct<'a> {
     #[schemars(inner(length(min = 5, max = 100)))]
     array_str_length: [&'a str; 2],
     #[schemars(inner(contains(pattern = "substring...")))]
-    slice_str_contains: &'a[&'a str],
+    slice_str_contains: &'a [&'a str],
     #[schemars(inner(regex = "STARTS_WITH_HELLO"))]
     vec_str_regex: Vec<String>,
     #[schemars(inner(length(min = 1, max = 100)))]

--- a/schemars_derive/Cargo.toml
+++ b/schemars_derive/Cargo.toml
@@ -17,8 +17,8 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
-serde_derive_internals = "0.26.0"
+syn = { version = "2.0", features = ["extra-traits"] }
+serde_derive_internals = "0.29.0"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -38,7 +38,7 @@ pub struct Field<'a> {
 }
 
 impl<'a> Container<'a> {
-    pub fn from_ast(item: &'a syn::DeriveInput) -> Result<Container<'a>, Vec<syn::Error>> {
+    pub fn from_ast(item: &'a syn::DeriveInput) -> Result<Container<'a>, syn::Error> {
         let ctxt = Ctxt::new();
         let result = serde_ast::Container::from_ast(&ctxt, item, Derive::Deserialize)
             .ok_or(())
@@ -48,7 +48,7 @@ impl<'a> Container<'a> {
             .map(|_| result.expect("from_ast set no errors on Ctxt, so should have returned Ok"))
     }
 
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &str {
         self.serde_attrs.name().deserialize_name()
     }
 
@@ -64,7 +64,7 @@ impl<'a> Container<'a> {
 }
 
 impl<'a> Variant<'a> {
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &str {
         self.serde_attrs.name().deserialize_name()
     }
 
@@ -74,7 +74,7 @@ impl<'a> Variant<'a> {
 }
 
 impl<'a> Field<'a> {
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &str {
         self.serde_attrs.name().deserialize_name()
     }
 }

--- a/schemars_derive/src/attr/doc.rs
+++ b/schemars_derive/src/attr/doc.rs
@@ -1,4 +1,4 @@
-use syn::{Attribute, Lit::Str, Meta::NameValue, MetaNameValue};
+use syn::Attribute;
 
 pub fn get_title_and_desc_from_doc(attrs: &[Attribute]) -> (Option<String>, Option<String>) {
     let doc = match get_doc(attrs) {
@@ -35,16 +35,18 @@ fn get_doc(attrs: &[Attribute]) -> Option<String> {
     let attrs = attrs
         .iter()
         .filter_map(|attr| {
-            if !attr.path.is_ident("doc") {
+            if !attr.path().is_ident("doc") {
                 return None;
             }
 
-            let meta = attr.parse_meta().ok()?;
-            if let NameValue(MetaNameValue { lit: Str(s), .. }) = meta {
-                return Some(s.value());
-            }
-
-            None
+            let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(litstr),
+                ..
+            }) = &attr.meta.require_name_value().ok()?.value
+            else {
+                return None;
+            };
+            Some(litstr.value())
         })
         .collect::<Vec<_>>();
 

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -2,7 +2,7 @@ use quote::ToTokens;
 use serde_derive_internals::Ctxt;
 use std::collections::HashSet;
 use syn::parse::Parser;
-use syn::{Attribute, Data, Field, Meta, NestedMeta, Variant};
+use syn::{Attribute, Data, Field, Variant};
 
 // List of keywords that can appear in #[serde(...)]/#[schemars(...)] attributes which we want serde_derive_internals to parse for us.
 pub(crate) static SERDE_KEYWORDS: &[&str] = &[
@@ -32,7 +32,7 @@ pub(crate) static SERDE_KEYWORDS: &[&str] = &[
 
 // If a struct/variant/field has any #[schemars] attributes, then create copies of them
 // as #[serde] attributes so that serde_derive_internals will parse them for us.
-pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), Vec<syn::Error>> {
+pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> Result<(), syn::Error> {
     let ctxt = Ctxt::new();
     process_attrs(&ctxt, &mut input.attrs);
     match input.data {
@@ -60,26 +60,45 @@ fn process_serde_field_attrs<'a>(ctxt: &Ctxt, fields: impl Iterator<Item = &'a m
 fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
     // Remove #[serde(...)] attributes (some may be re-added later)
     let (serde_attrs, other_attrs): (Vec<_>, Vec<_>) =
-        attrs.drain(..).partition(|at| at.path.is_ident("serde"));
+        attrs.drain(..).partition(|at| at.path().is_ident("serde"));
     *attrs = other_attrs;
 
-    let schemars_attrs: Vec<_> = attrs
-        .iter()
-        .filter(|at| at.path.is_ident("schemars"))
-        .collect();
-
     // Copy appropriate #[schemars(...)] attributes to #[serde(...)] attributes
-    let (mut serde_meta, mut schemars_meta_names): (Vec<_>, HashSet<_>) = schemars_attrs
+    let (mut serde_meta, mut schemars_meta_names): (Vec<_>, HashSet<_>) = attrs
         .iter()
-        .flat_map(|at| get_meta_items(ctxt, at))
-        .flatten()
-        .filter_map(|meta| {
-            let keyword = get_meta_ident(ctxt, &meta).ok()?;
-            if keyword.ends_with("with") || !SERDE_KEYWORDS.contains(&keyword.as_ref()) {
-                None
-            } else {
-                Some((meta, keyword))
+        .filter_map(|at| {
+            if !at.path().is_ident("schemars") {
+                return None;
             }
+
+            match at.meta.require_list() {
+                Ok(ml) => {
+                    match ml.parse_args_with(
+                        syn::punctuated::Punctuated::<syn::Meta, Token![,]>::parse_terminated,
+                    ) {
+                        Ok(meta) => Some(meta),
+                        Err(err) => {
+                            ctxt.syn_error(err);
+                            None
+                        }
+                    }
+                }
+                Err(_err) => {
+                    ctxt.error_spanned_by(at, "expected #[schemars(...)]");
+                    None
+                }
+            }
+        })
+        .flat_map(|ml| {
+            ml.into_iter().filter_map(|meta| {
+                let kw = meta.path().get_ident().map(|i| i.to_string())?;
+
+                if kw.ends_with("with") || !SERDE_KEYWORDS.contains(&kw.as_str()) {
+                    None
+                } else {
+                    Some((meta, kw))
+                }
+            })
         })
         .unzip();
 
@@ -89,19 +108,31 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
     }
 
     // Re-add #[serde(...)] attributes that weren't overridden by #[schemars(...)] attributes
-    for meta in serde_attrs
-        .into_iter()
-        .flat_map(|at| get_meta_items(ctxt, &at))
-        .flatten()
-    {
-        if let Ok(i) = get_meta_ident(ctxt, &meta) {
-            if !schemars_meta_names.contains(&i)
-                && SERDE_KEYWORDS.contains(&i.as_ref())
-                && i != "bound"
-            {
-                serde_meta.push(meta);
+    for attr in serde_attrs {
+        let ml = match attr.meta.require_list() {
+            Ok(ml) => ml,
+            Err(_err) => {
+                ctxt.error_spanned_by(attr, "expected #[serde(...)]");
+                continue;
             }
-        }
+        };
+
+        let Ok(ml) = ml
+            .parse_args_with(syn::punctuated::Punctuated::<syn::Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        serde_meta.extend(ml.into_iter().filter_map(|meta| {
+            let Some(kw) = meta.path().get_ident().map(|i| i.to_string()) else {
+                return None;
+            };
+
+            (kw != "bound"
+                && !schemars_meta_names.contains(&kw)
+                && SERDE_KEYWORDS.contains(&kw.as_ref()))
+            .then_some(meta)
+        }));
     }
 
     if !serde_meta.is_empty() {
@@ -123,36 +154,6 @@ fn to_tokens(attrs: &[Attribute]) -> impl ToTokens {
         attr.to_tokens(&mut tokens);
     }
     tokens
-}
-
-fn get_meta_items(ctxt: &Ctxt, attr: &Attribute) -> Result<Vec<NestedMeta>, ()> {
-    match attr.parse_meta() {
-        Ok(Meta::List(meta)) => Ok(meta.nested.into_iter().collect()),
-        Ok(_) => {
-            ctxt.error_spanned_by(attr, "expected #[schemars(...)] or #[serde(...)]");
-            Err(())
-        }
-        Err(err) => {
-            ctxt.error_spanned_by(attr, err);
-            Err(())
-        }
-    }
-}
-
-fn get_meta_ident(ctxt: &Ctxt, meta: &NestedMeta) -> Result<String, ()> {
-    match meta {
-        NestedMeta::Meta(m) => m.path().get_ident().map(|i| i.to_string()).ok_or(()),
-        NestedMeta::Lit(lit) => {
-            ctxt.error_spanned_by(
-                meta,
-                format!(
-                    "unexpected literal in attribute: {}",
-                    lit.into_token_stream()
-                ),
-            );
-            Err(())
-        }
-    }
 }
 
 #[cfg(test)]
@@ -198,7 +199,7 @@ mod tests {
         };
 
         if let Err(e) = process_serde_attrs(&mut input) {
-            panic!("process_serde_attrs returned error: {}", e[0])
+            panic!("process_serde_attrs returned error: {e}")
         };
 
         assert_eq!(input, expected);

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -32,10 +32,7 @@ pub fn derive_json_schema_repr_wrapper(input: proc_macro::TokenStream) -> proc_m
         .into()
 }
 
-fn derive_json_schema(
-    mut input: syn::DeriveInput,
-    repr: bool,
-) -> Result<TokenStream, Vec<syn::Error>> {
+fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> Result<TokenStream, syn::Error> {
     attr::process_serde_attrs(&mut input)?;
 
     let mut cont = Container::from_ast(&input)?;
@@ -87,7 +84,7 @@ fn derive_json_schema(
         });
     }
 
-    let mut schema_base_name = cont.name();
+    let mut schema_base_name = cont.name().to_owned();
 
     if !cont.attrs.is_renamed {
         if let Some(path) = cont.serde_attrs.remote() {
@@ -118,7 +115,7 @@ fn derive_json_schema(
             },
         )
     } else if cont.attrs.is_renamed {
-        let mut schema_name_fmt = schema_base_name;
+        let mut schema_name_fmt = schema_base_name.to_owned();
         for tp in &params {
             schema_name_fmt.push_str(&format!("{{{}:.0}}", tp));
         }
@@ -141,7 +138,7 @@ fn derive_json_schema(
             },
         )
     } else {
-        let mut schema_name_fmt = schema_base_name;
+        let mut schema_name_fmt = schema_base_name.to_owned();
         schema_name_fmt.push_str("_for_{}");
         schema_name_fmt.push_str(&"_and_{}".repeat(params.len() - 1));
         (
@@ -165,7 +162,7 @@ fn derive_json_schema(
     };
 
     let schema_expr = if repr {
-        schema_exprs::expr_for_repr(&cont).map_err(|e| vec![e])?
+        schema_exprs::expr_for_repr(&cont)?
     } else {
         schema_exprs::expr_for_container(&cont)
     };
@@ -208,9 +205,6 @@ fn add_trait_bounds(cont: &mut Container) {
     }
 }
 
-fn compile_error(errors: Vec<syn::Error>) -> TokenStream {
-    let compile_errors = errors.iter().map(syn::Error::to_compile_error);
-    quote! {
-        #(#compile_errors)*
-    }
+fn compile_error(error: syn::Error) -> TokenStream {
+    error.to_compile_error()
 }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -155,7 +155,7 @@ fn expr_for_external_tagged_enum<'a>(
     let mut count = 0;
     let (unit_variants, complex_variants): (Vec<_>, Vec<_>) = variants
         .inspect(|v| {
-            unique_names.insert(v.name());
+            unique_names.insert(v.name().into());
             count += 1;
         })
         .partition(|v| v.is_unit() && v.attrs.is_default());


### PR DESCRIPTION
This updates schemars_derive to use syn 2.0 and serde_derive_internals as much of crate ecosystem has moved from syn 1.0 and it's best to avoid duplicate dependencies, especially in proc macros.

Resolves: #262