### PR TITLE
Add optional support for `vec1::Vec1`

### DIFF
--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -36,6 +36,7 @@ bigdecimal04 = { version = "0.4", default-features = false, optional = true, pac
 enumset = { version = "1.0", optional = true }
 smol_str = { version = "0.1.17", optional = true }
 semver = { version = "1.0.9", features = ["serde"], optional = true }
+vec1 = { version = "1.10.1", features = ["serde"], optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -126,6 +127,10 @@ required-features = ["semver"]
 [[test]]
 name = "decimal"
 required-features = ["rust_decimal", "bigdecimal03", "bigdecimal04"]
+
+[[test]]
+name = "vec1"
+required-features = ["vec1"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -86,4 +86,6 @@ mod url;
 mod uuid08;
 #[cfg(feature = "uuid1")]
 mod uuid1;
+#[cfg(feature = "vec1")]
+mod vec1;
 mod wrapper;

--- a/schemars/src/json_schema_impls/vec1.rs
+++ b/schemars/src/json_schema_impls/vec1.rs
@@ -1,0 +1,27 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use vec1::Vec1;
+
+impl<T> JsonSchema for Vec1<T>
+where
+    T: JsonSchema,
+{
+    no_ref_schema!();
+
+    fn schema_name() -> String {
+        format!("Array_at_least_size_1_of_{}", T::schema_name())
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        SchemaObject {
+            instance_type: Some(InstanceType::Array.into()),
+            array: Some(Box::new(ArrayValidation {
+                items: Some(gen.subschema_for::<T>().into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
+    }
+}

--- a/schemars/tests/expected/vec1.json
+++ b/schemars/tests/expected/vec1.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_at_least_size_1_of_int32",
+  "type": "array",
+  "items": {
+    "type": "integer",
+    "format": "int32"
+  }
+}

--- a/schemars/tests/vec1.rs
+++ b/schemars/tests/vec1.rs
@@ -1,0 +1,7 @@
+mod util;
+use util::*;
+
+#[test]
+fn vec1() -> TestResult {
+    test_default_generated_schema::<vec1::Vec1<i32>>("vec1")
+}


### PR DESCRIPTION
This adds a `JsonSchema` impl for `vec1::Vec1`. I based the impl off similar types, so let me know if I missed anything! (also obligatory thanks for the great library :tada:)