### PR TITLE
Propagate `additional_properties` when using `#[serde(flatten)]`

### DIFF
--- a/schemars/src/flatten.rs
+++ b/schemars/src/flatten.rs
@@ -42,23 +42,16 @@ macro_rules! impl_merge {
 impl Merge for Option<Box<Schema>> {
     fn merge(self, other: Self) -> Self {
         match (self.map(|x| *x), other.map(|x| *x)) {
-            // Perfer permissive schemas.
+            // Prefer permissive schemas.
             (Some(Schema::Bool(true)), _) => Some(Box::new(true.into())),
             (_, Some(Schema::Bool(true))) => Some(Box::new(true.into())),
-            (None, _) => None,
-            (_, None) => None,
+            (Some(Schema::Bool(false)) | None, y) => y.map(Box::new),
+            (x, Some(Schema::Bool(false)) | None) => x.map(Box::new),
 
             // Merge if we have two non-trivial schemas.
             (Some(Schema::Object(s1)), Some(Schema::Object(s2))) => {
                 Some(Box::new(Schema::Object(s1.merge(s2))))
             }
-
-            // Perfer the more permissive schema.
-            (Some(s1 @ Schema::Object(_)), Some(Schema::Bool(false))) => Some(Box::new(s1)),
-            (Some(Schema::Bool(false)), Some(s2 @ Schema::Object(_))) => Some(Box::new(s2)),
-
-            // Default to the null schema.
-            (Some(Schema::Bool(false)), Some(Schema::Bool(false))) => Some(Box::new(false.into())),
         }
     }
 }

--- a/schemars/tests/expected/enum-internal.json
+++ b/schemars/tests/expected/enum-internal.json
@@ -28,6 +28,9 @@
             "StringMap"
           ]
         }
+      },
+      "additionalProperties": {
+        "type": "string"
       }
     },
     {


### PR DESCRIPTION
Fixes #259, motivated by https://github.com/stackabletech/operator-rs/pull/752

Whether `None` or `Some(Schema::Object(...))` is more permissive is arguably a matter of perspective. If you consider the JSON Schema to be a a _validation target_ then `None` could be argued to mean "and I don't care about anything else", while if it's a _normative schema_ then `None` would mean "and nothing else is accepted".

Following the latter interpretation, any non-`None` schema would be more permissive than `None`.

I also believe that the _expected_ behaviour is always that a "newtype" (a single flattened field) behaves identically to the type that it wraps, modulo explicitly requested differences.