### PR TITLE
Simplify generated enum code

### DIFF
--- a/schemars/src/_private.rs
+++ b/schemars/src/_private.rs
@@ -1,6 +1,5 @@
-use crate::flatten::Merge;
 use crate::gen::SchemaGenerator;
-use crate::schema::{InstanceType, Metadata, ObjectValidation, Schema, SchemaObject};
+use crate::schema::{InstanceType, ObjectValidation, Schema, SchemaObject};
 use crate::{JsonSchema, Map, Set};
 use serde::Serialize;
 use serde_json::Value;
@@ -23,16 +22,6 @@ pub fn json_schema_for_flatten<T: ?Sized + JsonSchema>(
     }
 
     schema
-}
-
-pub fn apply_metadata(schema: Schema, metadata: Metadata) -> Schema {
-    if metadata == Metadata::default() {
-        schema
-    } else {
-        let mut schema_obj = schema.into_object();
-        schema_obj.metadata = Some(Box::new(metadata)).merge(schema_obj.metadata);
-        Schema::Object(schema_obj)
-    }
 }
 
 /// Hack to simulate specialization:

--- a/schemars/src/_private.rs
+++ b/schemars/src/_private.rs
@@ -1,7 +1,7 @@
 use crate::flatten::Merge;
 use crate::gen::SchemaGenerator;
-use crate::schema::{Metadata, Schema, SchemaObject};
-use crate::JsonSchema;
+use crate::schema::{InstanceType, Metadata, ObjectValidation, Schema, SchemaObject};
+use crate::{JsonSchema, Map, Set};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -63,5 +63,120 @@ impl<T> NoSerialize for T {}
 impl<T: Serialize> MaybeSerializeWrapper<T> {
     pub fn maybe_to_value(self) -> Option<Value> {
         serde_json::value::to_value(self.0).ok()
+    }
+}
+
+/// Create a schema for a unit enum
+pub fn new_unit_enum(variant: &str) -> Schema {
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        enum_values: Some(vec![variant.into()]),
+        ..SchemaObject::default()
+    })
+}
+
+/// Create a schema for an externally tagged enum
+pub fn new_externally_tagged_enum(variant: &str, sub_schema: Schema) -> Schema {
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        object: Some(Box::new(ObjectValidation {
+            properties: {
+                let mut props = Map::new();
+                props.insert(variant.to_owned(), sub_schema);
+                props
+            },
+            required: {
+                let mut required = Set::new();
+                required.insert(variant.to_owned());
+                required
+            },
+            // Externally tagged variants must prohibit additional
+            // properties irrespective of the disposition of
+            // `deny_unknown_fields`. If additional properties were allowed
+            // one could easily construct an object that validated against
+            // multiple variants since here it's the properties rather than
+            // the values of a property that distingish between variants.
+            additional_properties: Some(Box::new(false.into())),
+            ..Default::default()
+        })),
+        ..SchemaObject::default()
+    })
+}
+
+/// Create a schema for an internally tagged enum
+pub fn new_internally_tagged_enum(
+    tag_name: &str,
+    variant: &str,
+    deny_unknown_fields: bool,
+) -> Schema {
+    let tag_schema = Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        enum_values: Some(vec![variant.into()]),
+        ..Default::default()
+    });
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Object.into()),
+        object: Some(Box::new(ObjectValidation {
+            properties: {
+                let mut props = Map::new();
+                props.insert(tag_name.to_owned(), tag_schema);
+                props
+            },
+            required: {
+                let mut required = Set::new();
+                required.insert(tag_name.to_owned());
+                required
+            },
+            additional_properties: deny_unknown_fields.then(|| Box::new(false.into())),
+            ..Default::default()
+        })),
+        ..SchemaObject::default()
+    })
+}
+
+pub fn insert_object_property<T: ?Sized + JsonSchema>(
+    obj: &mut ObjectValidation,
+    key: &str,
+    has_default: bool,
+    required: bool,
+    schema: Schema,
+) {
+    obj.properties.insert(key.to_owned(), schema);
+    if required || !(has_default || T::_schemars_private_is_option()) {
+        obj.required.insert(key.to_owned());
+    }
+}
+
+pub mod metadata {
+    use crate::Schema;
+    use serde_json::Value;
+
+    macro_rules! add_metadata_fn {
+        ($method:ident, $name:ident, $ty:ty) => {
+            pub fn $method(schema: Schema, $name: impl Into<$ty>) -> Schema {
+                let value = $name.into();
+                if value == <$ty>::default() {
+                    schema
+                } else {
+                    let mut schema_obj = schema.into_object();
+                    schema_obj.metadata().$name = value.into();
+                    Schema::Object(schema_obj)
+                }
+            }
+        };
+    }
+
+    add_metadata_fn!(add_description, description, String);
+    add_metadata_fn!(add_id, id, String);
+    add_metadata_fn!(add_title, title, String);
+    add_metadata_fn!(add_deprecated, deprecated, bool);
+    add_metadata_fn!(add_read_only, read_only, bool);
+    add_metadata_fn!(add_write_only, write_only, bool);
+    add_metadata_fn!(add_default, default, Value);
+
+    pub fn add_examples<I: IntoIterator<Item = Value>>(schema: Schema, examples: I) -> Schema {
+        let mut schema_obj = schema.into_object();
+        schema_obj.metadata().examples.extend(examples);
+        Schema::Object(schema_obj)
     }
 }

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -4,7 +4,6 @@ JSON Schema types.
 
 #[cfg(feature = "impl_json_schema")]
 use crate as schemars;
-#[cfg(feature = "impl_json_schema")]
 use crate::JsonSchema;
 use crate::{Map, Set};
 use serde::{Deserialize, Serialize};
@@ -533,6 +532,16 @@ pub struct ObjectValidation {
     /// See [JSON Schema 9.3.2.5. "propertyNames"](https://tools.ietf.org/html/draft-handrews-json-schema-02#section-9.3.2.5).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub property_names: Option<Box<Schema>>,
+}
+
+impl ObjectValidation {
+    pub fn insert_property<T: ?Sized + JsonSchema>(&mut self, key: &str, mut has_default: bool, required: bool, schema: Schema) {
+        self.properties.insert(key.to_owned(), schema);
+        has_default |= T::_schemars_private_is_option();
+        if required || !has_default {
+            self.required.insert(key.to_owned());
+        }
+    }
 }
 
 /// The possible types of values in JSON Schema documents.

--- a/schemars_derive/src/metadata.rs
+++ b/schemars_derive/src/metadata.rs
@@ -13,45 +13,32 @@ pub struct SchemaMetadata<'a> {
 
 impl<'a> SchemaMetadata<'a> {
     pub fn apply_to_schema(&self, schema_expr: &mut TokenStream) {
-        let setters = self.make_setters();
-        if !setters.is_empty() {
-            *schema_expr = quote! {{
-                let schema = #schema_expr;
-                #(let schema = schemars::_private::metadata::#setters;)*
-                schema
-            }}
-        }
-    }
-
-    fn make_setters(&self) -> Vec<TokenStream> {
-        let mut setters = Vec::<TokenStream>::new();
-
         if let Some(title) = &self.title {
-            setters.push(quote! {
-                add_title(schema, #title)
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_title(#schema_expr, #title)
+            };
         }
         if let Some(description) = &self.description {
-            setters.push(quote! {
-                add_description(schema, #description)
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_description(#schema_expr, #description)
+            };
         }
 
         if self.deprecated {
-            setters.push(quote! {
-                add_deprecated(schema, true)
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_deprecated(#schema_expr, true)
+            };
         }
 
         if self.read_only {
-            setters.push(quote! {
-                add_read_only(schema, true)
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_read_only(#schema_expr, true)
+            };
         }
         if self.write_only {
-            setters.push(quote! {
-                add_write_only(schema, true)
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_write_only(#schema_expr, true)
+            };
         }
 
         if !self.examples.is_empty() {
@@ -60,17 +47,16 @@ impl<'a> SchemaMetadata<'a> {
                     schemars::_serde_json::value::to_value(#eg())
                 }
             });
-            setters.push(quote! {
-                add_examples(schema, [#(#examples),*].into_iter().flatten())
-            });
+
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_examples(#schema_expr,  [#(#examples),*].into_iter().flatten())
+            };
         }
 
         if let Some(default) = &self.default {
-            setters.push(quote! {
-                add_default(schema, #default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
-            });
+            *schema_expr = quote! {
+                schemars::_private::metadata::add_default(#schema_expr, #default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
+            };
         }
-
-        setters
     }
 }

--- a/schemars_derive/src/metadata.rs
+++ b/schemars_derive/src/metadata.rs
@@ -17,7 +17,8 @@ impl<'a> SchemaMetadata<'a> {
         if !setters.is_empty() {
             *schema_expr = quote! {{
                 let schema = #schema_expr;
-                schema #(#setters)*
+                #(let schema = schemars::_private::metadata::#setters;)*
+                schema
             }}
         }
     }
@@ -27,29 +28,29 @@ impl<'a> SchemaMetadata<'a> {
 
         if let Some(title) = &self.title {
             setters.push(quote! {
-                .with_title(#title)
+                add_title(schema, #title)
             });
         }
         if let Some(description) = &self.description {
             setters.push(quote! {
-                .with_description(#description)
+                add_description(schema, #description)
             });
         }
 
         if self.deprecated {
             setters.push(quote! {
-                .with_deprecated(true)
+                add_deprecated(schema, true)
             });
         }
 
         if self.read_only {
             setters.push(quote! {
-                .with_read_only(true)
+                add_read_only(schema, true)
             });
         }
         if self.write_only {
             setters.push(quote! {
-                .with_write_only(true)
+                add_write_only(schema, true)
             });
         }
 
@@ -60,13 +61,13 @@ impl<'a> SchemaMetadata<'a> {
                 }
             });
             setters.push(quote! {
-                .with_examples([#(#examples),*].into_iter().flatten())
+                add_examples(schema, [#(#examples),*].into_iter().flatten())
             });
         }
 
         if let Some(default) = &self.default {
             setters.push(quote! {
-                .with_default(#default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
+                add_default(schema, #default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
             });
         }
 

--- a/schemars_derive/src/metadata.rs
+++ b/schemars_derive/src/metadata.rs
@@ -17,10 +17,7 @@ impl<'a> SchemaMetadata<'a> {
         if !setters.is_empty() {
             *schema_expr = quote! {{
                 let schema = #schema_expr;
-                schemars::_private::apply_metadata(schema, schemars::schema::Metadata {
-                    #(#setters)*
-                    ..Default::default()
-                })
+                schema #(#setters)*
             }}
         }
     }
@@ -30,29 +27,29 @@ impl<'a> SchemaMetadata<'a> {
 
         if let Some(title) = &self.title {
             setters.push(quote! {
-                title: Some(#title.to_owned()),
+                .with_title(#title)
             });
         }
         if let Some(description) = &self.description {
             setters.push(quote! {
-                description: Some(#description.to_owned()),
+                .with_description(#description)
             });
         }
 
         if self.deprecated {
             setters.push(quote! {
-                deprecated: true,
+                .with_deprecated(true)
             });
         }
 
         if self.read_only {
             setters.push(quote! {
-                read_only: true,
+                .with_read_only(true)
             });
         }
         if self.write_only {
             setters.push(quote! {
-                write_only: true,
+                .with_write_only(true)
             });
         }
 
@@ -63,13 +60,13 @@ impl<'a> SchemaMetadata<'a> {
                 }
             });
             setters.push(quote! {
-                examples: vec![#(#examples),*].into_iter().flatten().collect(),
+                .with_examples([#(#examples),*].into_iter().flatten())
             });
         }
 
         if let Some(default) = &self.default {
             setters.push(quote! {
-                default: #default.and_then(|d| schemars::_schemars_maybe_to_value!(d)),
+                .with_default(#default.and_then(|d| schemars::_schemars_maybe_to_value!(d)))
             });
         }
 

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -162,7 +162,7 @@ fn expr_for_external_tagged_enum<'a>(
     let unit_names = unit_variants.iter().map(|v| v.name());
     let unit_schema = schema_object(quote! {
         instance_type: Some(schemars::schema::InstanceType::String.into()),
-        enum_values: Some(vec![#(#unit_names.into()),*]),
+        enum_values: Some([#(#unit_names),*].into_iter().map(|v| v.into()).collect()),
     });
 
     if complex_variants.is_empty() {
@@ -178,10 +178,9 @@ fn expr_for_external_tagged_enum<'a>(
         let name = variant.name();
 
         let mut schema_expr = if variant.is_unit() && variant.attrs.with.is_none() {
-            schema_object(quote! {
-                instance_type: Some(schemars::schema::InstanceType::String.into()),
-                enum_values: Some(vec![#name.into()]),
-            })
+            quote! {
+                schemars::schema::Schema::new_unit_enum(#name)
+            }
         } else {
             let sub_schema = expr_for_untagged_enum_variant(variant, deny_unknown_fields);
             schema_object(quote! {

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -179,12 +179,12 @@ fn expr_for_external_tagged_enum<'a>(
 
         let mut schema_expr = if variant.is_unit() && variant.attrs.with.is_none() {
             quote! {
-                schemars::schema::Schema::new_unit_enum(#name)
+                schemars::_private::new_unit_enum(#name)
             }
         } else {
             let sub_schema = expr_for_untagged_enum_variant(variant, deny_unknown_fields);
             quote! {
-                schemars::schema::Schema::new_externally_tagged_enum(#name, #sub_schema)
+                schemars::_private::new_externally_tagged_enum(#name, #sub_schema)
             }
         };
 
@@ -214,7 +214,7 @@ fn expr_for_internal_tagged_enum<'a>(
             let name = variant.name();
 
             let mut tag_schema = quote! {
-                schemars::schema::Schema::new_internally_tagged_enum(#tag_name, #name, #deny_unknown_fields)
+                schemars::_private::new_internally_tagged_enum(#tag_name, #name, #deny_unknown_fields)
             };
 
             variant.attrs.as_metadata().apply_to_schema(&mut tag_schema);
@@ -477,7 +477,7 @@ fn expr_for_struct(
             quote! {
                 {
                     #type_def
-                    object_validation.insert_property::<#ty>(#name, #has_default, #required, #schema_expr);
+                    schemars::_private::insert_object_property::<#ty>(object_validation, #name, #has_default, #required, #schema_expr);
                 }
             }
         })


### PR DESCRIPTION
Mitigates #246 

Based on #266, but moves new functions into `_private` module. They are likely to be moved/changed when the structure of `Schema` changes, so I really don't want them to be part of the public API.

Description from original PR:
> Partial solution for #246
> 
> * replace the manual construction of `Schema::Object` with a helper method
> * replace metadata setting with a function call per-metadata
> 
> Taking the enum from https://github.com/adamchalmers/rust-problems/blob/achalmers/schemars-llvm-lines/src/lib.rs and running `cargo rustc -- -Z unpretty=mir | wc -l` it goes from 165725 lines of MIR to 4871 (removing the serde derives from the linked code)
> 
> The per-variant generate code goes from:
> 
> ```
> {
>     let schema = schemars::schema::Schema::Object(schemars::schema::SchemaObject {
>         instance_type: Some(
>             schemars::schema::InstanceType::String.into(),
>         ),
>         enum_values: Some(
>             <[_]>::into_vec(
>                 #[rustc_box]
>                 ::alloc::boxed::Box::new(["Af".into()]),
>             ),
>         ),
>         ..Default::default()
>     });
>     schemars::_private::apply_metadata(
>         schema,
>         schemars::schema::Metadata {
>             description: Some("Afghanistan".to_owned()),
>             ..Default::default()
>         },
>     )
> },
> ```
> 
> to:
> 
> ```rust
> {
>     let schema = schemars::schema::Schema::Object(
>         schemars::schema::SchemaObject::new_unit_enum("Af"),
>     );
>     schema.with_description("Afghanistan")
> },
> ```
> 
> ~I still have a [crate](https://github.com/demostf/parser) that takes forever to generate the schema for so there are still plenty of room for improvement.~

