### PR TITLE
README.md: Optimize writing schema to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ pub enum MyEnum {
 }
 
 let schema = schema_for!(MyStruct);
-println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+let mut stdout = std::io::stdout().lock();
+serde_json::to_writer_pretty(&mut stdout, &schema).unwrap();
 ```
 
 <details>


### PR DESCRIPTION
Silly drive-by PR but generating the JSON as a string to then print to stdout can be optimized by just writing to the stream directly.