### PR TITLE
Derive, use absolute import on `default` `serialize_with`

### DIFF
--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -562,7 +562,7 @@ fn field_default_expr(field: &Field, container_has_default: bool) -> Option<Toke
 
                 impl serde::Serialize for _SchemarsDefaultSerialize<#ty>
                 {
-                    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
                     where
                         S: serde::Serializer
                     {


### PR DESCRIPTION
This changes it so that the `Result` used in the derived schema code is using the absolute path to the `Result` enum, otherwise type aliases, such as: `error_stack::Result` cannot be used.

This has been observed when using `schemars` in conjunction with `serde-with`.