### PR TITLE
Do not collapse newlines in doc comments

### DIFF
--- a/docs/_includes/examples/doc_comments.schema.json
+++ b/docs/_includes/examples/doc_comments.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "My Amazing Struct",
-  "description": "This struct shows off generating a schema with a custom title and description.",
+  "description": "This struct shows off generating a schema with\na custom title and description.",
   "type": "object",
   "properties": {
     "my_bool": {
@@ -48,7 +48,7 @@
           ]
         },
         {
-          "description": "A struct-like enum variant which contains some floats",
+          "description": "A struct-like enum variant which contains\nsome floats",
           "type": "object",
           "properties": {
             "StructVariant": {

--- a/schemars/examples/doc_comments.schema.json
+++ b/schemars/examples/doc_comments.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "My Amazing Struct",
-  "description": "This struct shows off generating a schema with a custom title and description.",
+  "description": "This struct shows off generating a schema with\na custom title and description.",
   "type": "object",
   "properties": {
     "my_bool": {
@@ -48,7 +48,7 @@
           ]
         },
         {
-          "description": "A struct-like enum variant which contains some floats",
+          "description": "A struct-like enum variant which contains\nsome floats",
           "type": "object",
           "properties": {
             "StructVariant": {

--- a/schemars/tests/docs.rs
+++ b/schemars/tests/docs.rs
@@ -5,12 +5,10 @@ use util::*;
 #[allow(dead_code)]
 #[derive(JsonSchema)]
 /**
- *
- * # This is the struct's title
- *
- * This is the struct's description.
- *
- */
+# This is the struct's title
+
+This is the struct's description.
+*/
 struct MyStruct {
     /// # An integer
     my_int: i32,

--- a/schemars/tests/expected/doc_comments_enum.json
+++ b/schemars/tests/expected/doc_comments_enum.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "This is the enum's title",
-  "description": "This is the enum's description.",
+  "description": "This is \n the enum's description.",
   "oneOf": [
     {
       "type": "string",
@@ -25,7 +25,7 @@
           "properties": {
             "my_nullable_string": {
               "title": "A nullable string",
-              "description": "This field is a nullable string.\n\nThis is the second line!\n\nAnd this is the third!",
+              "description": "This field is a nullable string.\n\n This\nis\n   the second\n  line!\n\n\n\n\n And this is the third!",
               "type": [
                 "string",
                 "null"


### PR DESCRIPTION
Related issue: #120 

This is quite a significant change in behaviour so I don't think can reasonably be applied as a non-breaking change