### PR TITLE
Adjacent Tagged Enums should use if and else statements.

### DIFF
--- a/schemars/tests/enum.rs
+++ b/schemars/tests/enum.rs
@@ -1,7 +1,7 @@
 mod util;
 use std::collections::BTreeMap;
 
-use schemars::JsonSchema;
+use schemars::{schema_for, JsonSchema};
 use util::*;
 
 // Ensure that schemars_derive uses the full path to std::string::String
@@ -88,6 +88,33 @@ fn enum_untagged() -> TestResult {
 #[derive(JsonSchema)]
 #[schemars(tag = "t", content = "c")]
 enum Adjacent {
+    /// Has a description
+    UnitOne,
+    #[schemars(title = "String Map")]
+    StringMap(BTreeMap<&'static str, &'static str>),
+    UnitStructNewType(UnitStruct),
+    StructNewType(Struct),
+    Struct {
+        foo: i32,
+        bar: bool,
+    },
+    Tuple(i32, bool),
+    UnitTwo,
+    WithInt,
+}
+
+#[test]
+fn enum_adjacent_tagged() -> TestResult {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&schema_for!(Adjacent)).unwrap()
+    );
+    test_default_generated_schema::<Adjacent>("enum-adjacent-tagged")
+}
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(tag = "t", content = "c")]
+enum AdjacentNoExtras {
     UnitOne,
     StringMap(BTreeMap<&'static str, &'static str>),
     UnitStructNewType(UnitStruct),
@@ -101,12 +128,11 @@ enum Adjacent {
     #[schemars(with = "i32")]
     WithInt,
 }
-
 #[test]
-fn enum_adjacent_tagged() -> TestResult {
-    test_default_generated_schema::<Adjacent>("enum-adjacent-tagged")
-}
+fn enum_adjacent_tagged_no_extras() -> TestResult {
 
+    test_default_generated_schema::<AdjacentNoExtras>("enum-adjacent-tagged-no-extras")
+}
 #[allow(dead_code)]
 #[derive(JsonSchema)]
 #[schemars(tag = "typeProperty")]

--- a/schemars/tests/expected/enum-adjacent-tagged-duf.json
+++ b/schemars/tests/expected/enum-adjacent-tagged-duf.json
@@ -1,200 +1,189 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Adjacent",
-  "oneOf": [
+  "properties": {
+    "t": {
+      "type": "string",
+      "enum": [
+        "UnitOne",
+        "StringMap",
+        "UnitStructNewType",
+        "StructNewType",
+        "Struct",
+        "Tuple",
+        "UnitTwo",
+        "WithInt"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
     {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "UnitOne"
-          ]
-        }
-      },
-      "required": [
-        "t"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "StringMap"
-          ]
-        },
-        "c": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+      "if": {
+        "properties": {
+          "t": {
+            "const": "StringMap"
           }
         }
       },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "UnitStructNewType"
-          ]
-        },
-        "c": {
-          "$ref": "#/$defs/UnitStruct"
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "StructNewType"
-          ]
-        },
-        "c": {
-          "$ref": "#/$defs/Struct"
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Struct"
-          ]
-        },
-        "c": {
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "bar": {
-              "type": "boolean"
+      "then": {
+        "properties": {
+          "c": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false,
-          "required": [
-            "foo",
-            "bar"
-          ]
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
     },
     {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Tuple"
-          ]
+      "if": {
+        "properties": {
+          "t": {
+            "const": "UnitStructNewType"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "$ref": "#/$defs/UnitStruct"
+          }
         },
-        "c": {
-          "type": "array",
-          "prefixItems": [
-            {
-              "type": "integer",
-              "format": "int32"
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "StructNewType"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "$ref": "#/$defs/Struct"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Struct"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "object",
+            "properties": {
+              "bar": {
+                "type": "boolean"
+              },
+              "foo": {
+                "type": "integer",
+                "format": "int32"
+              }
             },
-            {
-              "type": "boolean"
-            }
-          ],
-          "minItems": 2,
-          "maxItems": 2
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "UnitTwo"
-          ]
-        }
-      },
-      "required": [
-        "t"
-      ],
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "WithInt"
-          ]
+            "additionalProperties": false,
+            "required": [
+              "foo",
+              "bar"
+            ]
+          }
         },
-        "c": {
-          "type": "integer",
-          "format": "int32"
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Tuple"
+          }
         }
       },
-      "required": [
-        "t",
-        "c"
-      ],
-      "additionalProperties": false
+      "then": {
+        "properties": {
+          "c": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer",
+                "format": "int32"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "WithInt"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
     }
   ],
+  "required": [
+    "t"
+  ],
   "$defs": {
-    "UnitStruct": {
-      "type": "null"
-    },
     "Struct": {
       "type": "object",
       "properties": {
+        "bar": {
+          "type": "boolean"
+        },
         "foo": {
           "type": "integer",
           "format": "int32"
-        },
-        "bar": {
-          "type": "boolean"
         }
       },
       "required": [
         "foo",
         "bar"
       ]
+    },
+    "UnitStruct": {
+      "type": "null"
     }
   }
 }

--- a/schemars/tests/expected/enum-adjacent-tagged-no-extras.json
+++ b/schemars/tests/expected/enum-adjacent-tagged-no-extras.json
@@ -1,49 +1,23 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Adjacent",
+  "title": "AdjacentNoExtras",
   "properties": {
     "t": {
-      "oneOf": [
-        {
-          "description": "Has a description",
-          "type": "string",
-          "const": "UnitOne"
-        },
-        {
-          "title": "String Map",
-          "type": "string",
-          "const": "StringMap"
-        },
-        {
-          "type": "string",
-          "const": "UnitStructNewType"
-        },
-        {
-          "type": "string",
-          "const": "StructNewType"
-        },
-        {
-          "type": "string",
-          "const": "Struct"
-        },
-        {
-          "type": "string",
-          "const": "Tuple"
-        },
-        {
-          "type": "string",
-          "const": "UnitTwo"
-        },
-        {
-          "type": "string",
-          "const": "WithInt"
-        }
+      "type": "string",
+      "enum": [
+        "UnitOne",
+        "StringMap",
+        "UnitStructNewType",
+        "StructNewType",
+        "Struct",
+        "Tuple",
+        "UnitTwo",
+        "WithInt"
       ]
     }
   },
   "allOf": [
     {
-      "title": "String Map",
       "if": {
         "properties": {
           "t": {
@@ -158,6 +132,26 @@
                 "type": "boolean"
               }
             ]
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "WithInt"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "required": [

--- a/schemars/tests/expected/extend_enum_adjacent.json
+++ b/schemars/tests/expected/extend_enum_adjacent.json
@@ -1,101 +1,103 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Adjacent",
-  "oneOf": [
+  "properties": {
+    "t": {
+      "type": "string",
+      "enum": [
+        "Unit",
+        "NewType",
+        "Tuple",
+        "Struct"
+      ]
+    }
+  },
+  "allOf": [
     {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Unit"
-          ]
+      "foo": "bar",
+      "if": {
+        "properties": {
+          "t": {
+            "const": "NewType"
+          }
         }
       },
-      "required": [
-        "t"
-      ],
-      "foo": "bar"
+      "then": {
+        "properties": {
+          "c": true
+        },
+        "required": [
+          "c"
+        ]
+      }
     },
     {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "NewType"
-          ]
-        },
-        "c": true
+      "foo": "bar",
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Tuple"
+          }
+        }
       },
-      "required": [
-        "t",
-        "c"
-      ],
-      "foo": "bar"
+      "then": {
+        "properties": {
+          "c": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer",
+                "format": "int32"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
     },
     {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Tuple"
-          ]
-        },
-        "c": {
-          "type": "array",
-          "prefixItems": [
-            {
-              "type": "integer",
-              "format": "int32"
+      "foo": "bar",
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Struct"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "object",
+            "properties": {
+              "b": {
+                "type": "boolean"
+              },
+              "i": {
+                "type": "integer",
+                "format": "int32"
+              }
             },
-            {
-              "type": "boolean"
-            }
-          ],
-          "minItems": 2,
-          "maxItems": 2
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "foo": "bar"
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Struct"
-          ]
+            "required": [
+              "i",
+              "b"
+            ]
+          }
         },
-        "c": {
-          "type": "object",
-          "properties": {
-            "i": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "b": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "i",
-            "b"
-          ]
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ],
-      "foo": "bar"
+        "required": [
+          "c"
+        ]
+      }
     }
   ],
-  "foo": "bar"
+  "foo": "bar",
+  "required": [
+    "t"
+  ]
 }

--- a/schemars/tests/expected/schema_with-enum-adjacent-tagged.json
+++ b/schemars/tests/expected/schema_with-enum-adjacent-tagged.json
@@ -1,97 +1,115 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Adjacent",
-  "oneOf": [
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Struct"
-          ]
-        },
-        "c": {
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "foo"
-          ]
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "NewType"
-          ]
-        },
-        "c": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Tuple"
-          ]
-        },
-        "c": {
-          "type": "array",
-          "prefixItems": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "integer",
-              "format": "int32"
-            }
-          ],
-          "minItems": 2,
-          "maxItems": 2
-        }
-      },
-      "required": [
-        "t",
-        "c"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
-        "t": {
-          "type": "string",
-          "enum": [
-            "Unit"
-          ]
-        },
-        "c": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "t",
-        "c"
+  "properties": {
+    "t": {
+      "type": "string",
+      "enum": [
+        "Struct",
+        "NewType",
+        "Tuple",
+        "Unit"
       ]
     }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Struct"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "object",
+            "properties": {
+              "foo": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "foo"
+            ]
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "NewType"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Tuple"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ]
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "t": {
+            "const": "Unit"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "c": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    }
+  ],
+  "required": [
+    "t"
   ]
 }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -324,7 +324,7 @@ fn expr_for_adjacent_tagged_enum<'a>(
     }
     let set_additional_properties = if deny_unknown_fields {
         quote! {
-            map.insert("additionalProperties", false.into());
+            map.insert("additionalProperties".to_owned(), false.into());
         }
     } else {
         TokenStream::new()
@@ -358,8 +358,9 @@ fn expr_for_adjacent_tagged_enum<'a>(
             }));
         }
     };
-    quote! {
-        let mut map = schemars::_serde_json::Map::new();
+    quote! (
+    {
+    let mut map = schemars::_serde_json::Map::new();
         #tag_property
         map.insert("properties".to_owned(), schemars::_serde_json::json!({
             #tag_name: tag_properties
@@ -373,7 +374,8 @@ fn expr_for_adjacent_tagged_enum<'a>(
             enum_values
         }));
         schemars::Schema::from(map)
-    }
+     }
+    )
 }
 
 /// Callers must determine if all subschemas are mutually exclusive. This can


### PR DESCRIPTION
So using if then else statements for the adjacently tagged enums is a cleaner way and closer to what the docs recommend.

[Docs](https://json-schema.org/understanding-json-schema/reference/conditionals#ifthenelse)

Also now it will also use `oneOf` for the enum if enum has a description or title. 