### PR TITLE
Add support for multiple flatten enums

### DIFF
--- a/schemars/src/_private.rs
+++ b/schemars/src/_private.rs
@@ -209,6 +209,20 @@ pub fn flatten(schema: &mut Schema, other: Schema) {
                                     }
                                 }
                             }
+                            "oneOf" => {
+                                if let a1 @ Value::Array(_) = occupied.get().clone() {
+                                    occupied.remove();
+                                    let all_of = Value::Array(vec![
+                                        json!({
+                                          "oneOf": a1
+                                        }),
+                                        json!({
+                                          "oneOf": value2
+                                        }),
+                                    ]);
+                                    obj1.insert("allOf".to_string(), all_of);
+                                }
+                            }
                             _ => {
                                 // leave the original value as it is (don't modify `schema`)
                             }

--- a/schemars/src/_private.rs
+++ b/schemars/src/_private.rs
@@ -194,7 +194,7 @@ pub fn flatten(schema: &mut Schema, other: Schema) {
             },
             Entry::Occupied(occupied) => {
                 match occupied.key().as_str() {
-                    "required" => {
+                    "required" | "allOf" => {
                         if let Value::Array(a1) = occupied.into_mut() {
                             if let Value::Array(a2) = value2 {
                                 a1.extend(a2);
@@ -227,13 +227,6 @@ pub fn flatten(schema: &mut Schema, other: Schema) {
                                 { key: value2 }
                             ]),
                         );
-                    }
-                    "allOf" => {
-                        if let Value::Array(a1) = occupied.into_mut() {
-                            if let Value::Array(a2) = value2 {
-                                a1.extend(a2);
-                            }
-                        }
                     }
                     _ => {
                         // leave the original value as it is (don't modify `schema`)

--- a/schemars/src/json_schema_impls/chrono04.rs
+++ b/schemars/src/json_schema_impls/chrono04.rs
@@ -1,7 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
-use chrono04::prelude::*;
 use alloc::borrow::Cow;
+use chrono04::prelude::*;
 
 impl JsonSchema for Weekday {
     always_inline!();

--- a/schemars/src/json_schema_impls/semver1.rs
+++ b/schemars/src/json_schema_impls/semver1.rs
@@ -1,7 +1,7 @@
 use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
-use semver1::Version;
 use alloc::borrow::Cow;
+use semver1::Version;
 
 impl JsonSchema for Version {
     always_inline!();

--- a/schemars/tests/enum_flatten.rs
+++ b/schemars/tests/enum_flatten.rs
@@ -1,0 +1,33 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "Flat")]
+struct Flat {
+    f: f32,
+    #[schemars(flatten)]
+    e1: Enum1,
+    #[schemars(flatten)]
+    e2: Enum2,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum1 {
+    B(bool),
+    S(String),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum2 {
+    U(u32),
+    F(f64),
+}
+
+#[test]
+fn test_flat_schema() -> TestResult {
+    test_default_generated_schema::<Flat>("enum_flatten")
+}

--- a/schemars/tests/enum_flatten.rs
+++ b/schemars/tests/enum_flatten.rs
@@ -11,6 +11,12 @@ struct Flat {
     e1: Enum1,
     #[schemars(flatten)]
     e2: Enum2,
+    #[schemars(flatten)]
+    e3: Enum3,
+    #[schemars(flatten)]
+    e4: Enum4,
+    #[schemars(flatten)]
+    e5: Enum5,
 }
 
 #[allow(dead_code)]
@@ -25,6 +31,27 @@ enum Enum1 {
 enum Enum2 {
     U(u32),
     F(f64),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum3 {
+    B2(bool),
+    S2(String),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum4 {
+    U2(u32),
+    F2(f64),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+enum Enum5 {
+    B3(bool),
+    S3(String),
 }
 
 #[test]

--- a/schemars/tests/expected/enum_flatten.json
+++ b/schemars/tests/expected/enum_flatten.json
@@ -70,6 +70,91 @@
           "additionalProperties": false
         }
       ]
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "B2": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "B2"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "S2": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "S2"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "U2": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "U2"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "F2": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "required": [
+            "F2"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  ],
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "B3": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "B3"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "S3": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "S3"
+      ],
+      "additionalProperties": false
     }
   ]
 }

--- a/schemars/tests/expected/enum_flatten.json
+++ b/schemars/tests/expected/enum_flatten.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Flat",
+  "type": "object",
+  "properties": {
+    "f": {
+      "type": "number",
+      "format": "float"
+    }
+  },
+  "required": [
+    "f"
+  ],
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "B": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "B"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "S": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "S"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "U": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "U"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "F": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "required": [
+            "F"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Update #264 following v1 merge on master.

> Fix https://github.com/GREsau/schemars/issues/165.
>
> Use all_of when flattening multiple subschemas.
>
> There is still a limitation when flattening required enum. We lose the information that the field is required. This is not caused by this PR. This could be fix in another PR.
>
> We use this fix in [apistos](https://github.com/netwo-io/apistos).