### PR TITLE
Remove usages of `gen` identifier

### DIFF
--- a/docs/1.1-attributes.md
+++ b/docs/1.1-attributes.md
@@ -267,7 +267,7 @@ Validator docs: [required](https://github.com/Keats/validator#required) / [requi
 
 </h3>
 
-Set on a variant or field to generate this field's schema using the given function. This function must be callable as `fn(&mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema`.
+Set on a variant or field to generate this field's schema using the given function. This function must be callable as `fn(&mut schemars::SchemaGenerator) -> schemars::schema::Schema`.
 
 <h3 id="title-description">
 

--- a/docs/2-implementing.md
+++ b/docs/2-implementing.md
@@ -60,10 +60,10 @@ The default implementation of this function returns `Self::schema_name()`.
 ## json_schema
 
 ```rust
-fn json_schema(gen: &mut gen::SchemaGenerator) -> Schema;
+fn json_schema(generator: &mut SchemaGenerator) -> Schema;
 ```
 
-This function creates the JSON schema itself. The `gen` argument can be used to check the schema generation settings, or to get schemas for other types. If you do need schemas for other types, you should call the `gen.subschema_for::<T>()` method instead of `<T>::json_schema(gen)`, as `subschema_for` can add `T`'s schema to the root schema's `$defs` so that it does not need to be duplicated when used more than once.
+This function creates the JSON schema itself. The `generator` argument can be used to check the schema generation settings, or to get schemas for other types. If you do need schemas for other types, you should call the `generator.subschema_for::<T>()` method instead of `<T>::json_schema(generator)`, as `subschema_for` can add `T`'s schema to the root schema's `$defs` so that it does not need to be duplicated when used more than once.
 
 `json_schema` should not return a `$ref` schema.
 

--- a/docs/3-generating.md
+++ b/docs/3-generating.md
@@ -6,7 +6,7 @@ permalink: /generating/
 
 # Generating Schemas
 
-The easiest way to generate a schema for a type that implements is to use the [`schema_for!` macro](https://docs.rs/schemars/latest/schemars/macro.schema_for.html), like so:
+The easiest way to generate a schema for a type that implements is to use the [`schema_for!` macro](https://docs.rs/schemars/1.0.0--latest/schemars/macro.schema_for.html), like so:
 
 ```rust
 let my_schema = schema_for!(MyStruct);
@@ -14,10 +14,10 @@ let my_schema = schema_for!(MyStruct);
 
 This will create a schema that conforms to [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12), but this is liable to change in a future version of Schemars if support for other JSON Schema versions is added.
 
-If you want more control over how the schema is generated, you can use the [`gen` module](https://docs.rs/schemars/latest/schemars/gen/). There are two main types in this module:
+If you want more control over how the schema is generated, you can use the [`generate` module](https://docs.rs/schemars/1.0.0--latest/schemars/generate/). There are two main types in this module:
 
-- [`SchemaSettings`](https://docs.rs/schemars/latest/schemars/gen/struct.SchemaSettings.html), which defines what JSON Schema features should be used when generating schemas (for example, how `Option`s should be represented).
-- [`SchemaGenerator`](https://docs.rs/schemars/latest/schemars/gen/struct.SchemaGenerator.html), which manages the generation of a schema document.
+- [`SchemaSettings`](https://docs.rs/schemars/1.0.0--latest/schemars/generate/struct.SchemaSettings.html), which defines what JSON Schema features should be used when generating schemas (for example, how `Option`s should be represented).
+- [`SchemaGenerator`](https://docs.rs/schemars/1.0.0--latest/schemars/generate/struct.SchemaGenerator.html), which manages the generation of a schema document.
 
 For example, to generate a schema that conforms to [JSON Schema Draft 7](https://json-schema.org/specification-links.html#draft-7):
 
@@ -30,7 +30,7 @@ See the API documentation for more info on how to use those types for custom sch
 
 ## Schema from Example Value
 
-If you want a schema for a type that can't/doesn't implement `JsonSchema`, but does implement `serde::Serialize`, then you can generate a JSON schema from a value of that type using the [`schema_for_value!` macro](https://docs.rs/schemars/latest/schemars/macro.schema_for_value.html). However, this schema will generally be less precise than if the type implemented `JsonSchema` - particularly when it involves enums, since schemars will not make any assumptions about the structure of an enum based on a single variant.
+If you want a schema for a type that can't/doesn't implement `JsonSchema`, but does implement `serde::Serialize`, then you can generate a JSON schema from a value of that type using the [`schema_for_value!` macro](https://docs.rs/schemars/1.0.0--latest/schemars/macro.schema_for_value.html). However, this schema will generally be less precise than if the type implemented `JsonSchema` - particularly when it involves enums, since schemars will not make any assumptions about the structure of an enum based on a single variant.
 
 ```rust
 let value = MyStruct { foo = 123 };

--- a/docs/_includes/examples/custom_serialization.rs
+++ b/docs/_includes/examples/custom_serialization.rs
@@ -19,8 +19,8 @@ pub struct MyStruct {
     pub bool_normal: bool,
 }
 
-fn make_custom_schema(gen: &mut SchemaGenerator) -> Schema {
-    let mut schema = String::json_schema(gen);
+fn make_custom_schema(generator: &mut SchemaGenerator) -> Schema {
+    let mut schema = String::json_schema(generator);
     schema
         .ensure_object()
         .insert("format".into(), "boolean".into());

--- a/docs/_includes/examples/custom_settings.rs
+++ b/docs/_includes/examples/custom_settings.rs
@@ -1,4 +1,4 @@
-use schemars::{gen::SchemaSettings, JsonSchema};
+use schemars::{generate::SchemaSettings, JsonSchema};
 
 #[derive(JsonSchema)]
 pub struct MyStruct {
@@ -18,7 +18,7 @@ fn main() {
         s.option_nullable = true;
         s.option_add_null_type = false;
     });
-    let gen = settings.into_generator();
-    let schema = gen.into_root_schema_for::<MyStruct>();
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<MyStruct>();
     println!("{}", serde_json::to_string_pretty(&schema).unwrap());
 }

--- a/docs/examples/4-custom_settings.md
+++ b/docs/examples/4-custom_settings.md
@@ -7,6 +7,6 @@ summary: Generating a schema using custom settings which changes how Option<T> i
 
 # Custom Schema Settings
 
-The `gen` module allows you to customise how schemas are generated. For example, the default behaviour for `Option<T>` is to include `null` in the schema's `type`s, but we can instead add a `nullable` property to its schema:
+The `generate` module allows you to customise how schemas are generated. For example, the default behaviour for `Option<T>` is to include `null` in the schema's `type`s, but we can instead add a `nullable` property to its schema:
 
 {% include example.md name="custom_settings" %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 Schemars is a library to generate JSON Schema documents from Rust data structures.
 
-This is built on Rust's trait system - any type which implements the [`JsonSchema`](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html) trait can have a JSON Schema generated describing that type. Schemars implements this on many standard library types, and provides a derive macro to automatically implement it on custom types.
+This is built on Rust's trait system - any type which implements the [`JsonSchema`](https://docs.rs/schemars/1.0.0--latest/schemars/trait.JsonSchema.html) trait can have a JSON Schema generated describing that type. Schemars implements this on many standard library types, and provides a derive macro to automatically implement it on custom types.
 
 One of the main aims of this library is compatibility with [Serde](https://github.com/serde-rs/serde). Any generated schema _should_ match how [serde_json](https://github.com/serde-rs/json) would serialize/deserialize to/from JSON. To support this, Schemars will check for any `#[serde(...)]` attributes on types that derive `JsonSchema`, and adjust the generated schema accordingly.
 

--- a/schemars/examples/custom_serialization.rs
+++ b/schemars/examples/custom_serialization.rs
@@ -19,8 +19,8 @@ pub struct MyStruct {
     pub bool_normal: bool,
 }
 
-fn make_custom_schema(gen: &mut SchemaGenerator) -> Schema {
-    let mut schema = String::json_schema(gen);
+fn make_custom_schema(generator: &mut SchemaGenerator) -> Schema {
+    let mut schema = String::json_schema(generator);
     schema
         .ensure_object()
         .insert("format".into(), "boolean".into());

--- a/schemars/examples/custom_settings.rs
+++ b/schemars/examples/custom_settings.rs
@@ -1,4 +1,4 @@
-use schemars::{gen::SchemaSettings, JsonSchema};
+use schemars::{generate::SchemaSettings, JsonSchema};
 
 #[derive(JsonSchema)]
 pub struct MyStruct {
@@ -18,7 +18,7 @@ fn main() {
         s.option_nullable = true;
         s.option_add_null_type = false;
     });
-    let gen = settings.into_generator();
-    let schema = gen.into_root_schema_for::<MyStruct>();
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<MyStruct>();
     println!("{}", serde_json::to_string_pretty(&schema).unwrap());
 }

--- a/schemars/src/_private.rs
+++ b/schemars/src/_private.rs
@@ -5,10 +5,10 @@ use serde_json::{json, map::Entry, Map, Value};
 
 // Helper for generating schemas for flattened `Option` fields.
 pub fn json_schema_for_flatten<T: ?Sized + JsonSchema>(
-    gen: &mut SchemaGenerator,
+    generator: &mut SchemaGenerator,
     required: bool,
 ) -> Schema {
-    let mut schema = T::_schemars_private_non_optional_json_schema(gen);
+    let mut schema = T::_schemars_private_non_optional_json_schema(generator);
 
     if T::_schemars_private_is_option() && !required {
         if let Some(object) = schema.as_object_mut() {

--- a/schemars/src/json_schema_impls/array.rs
+++ b/schemars/src/json_schema_impls/array.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 
@@ -37,10 +37,10 @@ macro_rules! array_impls {
                     format!("[{}; {}]", $len, T::schema_id()).into()
                 }
 
-                fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+                fn json_schema(generator: &mut SchemaGenerator) -> Schema {
                     json_schema!({
                         "type": "array",
-                        "items": serde_json::Value::from(gen.subschema_for::<T>()),
+                        "items": serde_json::Value::from(generator.subschema_for::<T>()),
                         "minItems": $len,
                         "maxItems": $len,
                     })

--- a/schemars/src/json_schema_impls/arrayvec07.rs
+++ b/schemars/src/json_schema_impls/arrayvec07.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use arrayvec07::{ArrayString, ArrayVec};
 
@@ -17,10 +17,10 @@ where
         format!("Array_up_to_size_{}_of_{}", CAP, T::schema_name()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "array",
-            "items": gen.subschema_for::<T>(),
+            "items": generator.subschema_for::<T>(),
             "maxItems": CAP
         })
     }

--- a/schemars/src/json_schema_impls/chrono04.rs
+++ b/schemars/src/json_schema_impls/chrono04.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use chrono04::prelude::*;

--- a/schemars/src/json_schema_impls/core.rs
+++ b/schemars/src/json_schema_impls/core.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use core::ops::{Bound, Range, RangeInclusive};
@@ -16,10 +16,10 @@ impl<T: JsonSchema> JsonSchema for Option<T> {
         format!("Option<{}>", T::schema_id()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        let mut schema = gen.subschema_for::<T>();
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let mut schema = generator.subschema_for::<T>();
 
-        if gen.settings().option_add_null_type {
+        if generator.settings().option_add_null_type {
             schema = match schema.try_to_object() {
                 Ok(mut obj) => {
                     let instance_type = obj.get_mut("type");
@@ -43,17 +43,17 @@ impl<T: JsonSchema> JsonSchema for Option<T> {
                         _ => json_schema!({
                             "anyOf": [
                                 obj,
-                                <()>::json_schema(gen)
+                                <()>::json_schema(generator)
                             ]
                         }),
                     }
                 }
                 Err(true) => true.into(),
-                Err(false) => <()>::json_schema(gen),
+                Err(false) => <()>::json_schema(generator),
             }
         }
 
-        if gen.settings().option_nullable {
+        if generator.settings().option_nullable {
             schema
                 .ensure_object()
                 .insert("nullable".into(), true.into());
@@ -62,8 +62,8 @@ impl<T: JsonSchema> JsonSchema for Option<T> {
         schema
     }
 
-    fn _schemars_private_non_optional_json_schema(gen: &mut SchemaGenerator) -> Schema {
-        T::_schemars_private_non_optional_json_schema(gen)
+    fn _schemars_private_non_optional_json_schema(generator: &mut SchemaGenerator) -> Schema {
+        T::_schemars_private_non_optional_json_schema(generator)
     }
 
     fn _schemars_private_is_option() -> bool {
@@ -80,20 +80,20 @@ impl<T: JsonSchema, E: JsonSchema> JsonSchema for Result<T, E> {
         format!("Result<{}, {}>", T::schema_id(), E::schema_id()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "oneOf": [
                 {
                     "type": "object",
                     "properties": {
-                        "Ok": gen.subschema_for::<T>()
+                        "Ok": generator.subschema_for::<T>()
                     },
                     "required": ["Ok"]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "Err": gen.subschema_for::<E>()
+                        "Err": generator.subschema_for::<E>()
                     },
                     "required": ["Err"]
                 }
@@ -111,20 +111,20 @@ impl<T: JsonSchema> JsonSchema for Bound<T> {
         format!("Bound<{}>", T::schema_id()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "oneOf": [
                 {
                     "type": "object",
                     "properties": {
-                        "Included": gen.subschema_for::<T>()
+                        "Included": generator.subschema_for::<T>()
                     },
                     "required": ["Included"]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "Excluded": gen.subschema_for::<T>()
+                        "Excluded": generator.subschema_for::<T>()
                     },
                     "required": ["Excluded"]
                 },
@@ -146,8 +146,8 @@ impl<T: JsonSchema> JsonSchema for Range<T> {
         format!("Range<{}>", T::schema_id()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        let subschema = gen.subschema_for::<T>();
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        let subschema = generator.subschema_for::<T>();
         json_schema!({
             "type": "object",
             "properties": {

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 

--- a/schemars/src/json_schema_impls/either1.rs
+++ b/schemars/src/json_schema_impls/either1.rs
@@ -1,5 +1,5 @@
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use either1::Either;
@@ -15,9 +15,9 @@ impl<L: JsonSchema, R: JsonSchema> JsonSchema for Either<L, R> {
         format!("either::Either<{}, {}>", L::schema_id(), R::schema_id()).into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
-            "anyOf": [gen.subschema_for::<L>(), gen.subschema_for::<R>()],
+            "anyOf": [generator.subschema_for::<L>(), generator.subschema_for::<R>()],
         })
     }
 }

--- a/schemars/src/json_schema_impls/ffi.rs
+++ b/schemars/src/json_schema_impls/ffi.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
@@ -13,20 +13,20 @@ impl JsonSchema for OsString {
         "std::ffi::OsString".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "oneOf": [
                 {
                     "type": "object",
                     "properties": {
-                        "Unix": <Vec<u8>>::json_schema(gen)
+                        "Unix": <Vec<u8>>::json_schema(generator)
                     },
                     "required": ["Unix"]
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "Windows": <Vec<u16>>::json_schema(gen)
+                        "Windows": <Vec<u16>>::json_schema(generator)
                     },
                     "required": ["Windows"]
                 },

--- a/schemars/src/json_schema_impls/maps.rs
+++ b/schemars/src/json_schema_impls/maps.rs
@@ -1,5 +1,5 @@
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 
@@ -19,10 +19,10 @@ macro_rules! map_impl {
                 format!("Map<{}>", V::schema_id()).into()
             }
 
-            fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
                 json_schema!({
                     "type": "object",
-                    "additionalProperties": gen.subschema_for::<V>(),
+                    "additionalProperties": generator.subschema_for::<V>(),
                 })
             }
         }

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -21,12 +21,12 @@ macro_rules! forward_impl {
                 <$target>::schema_id()
             }
 
-            fn json_schema(gen: &mut $crate::gen::SchemaGenerator) -> $crate::Schema {
-                <$target>::json_schema(gen)
+            fn json_schema(generator: &mut $crate::SchemaGenerator) -> $crate::Schema {
+                <$target>::json_schema(generator)
             }
 
-            fn _schemars_private_non_optional_json_schema(gen: &mut $crate::gen::SchemaGenerator) -> $crate::Schema {
-                <$target>::_schemars_private_non_optional_json_schema(gen)
+            fn _schemars_private_non_optional_json_schema(generator: &mut $crate::SchemaGenerator) -> $crate::Schema {
+                <$target>::_schemars_private_non_optional_json_schema(generator)
             }
 
             fn _schemars_private_is_option() -> bool {

--- a/schemars/src/json_schema_impls/nonzero_signed.rs
+++ b/schemars/src/json_schema_impls/nonzero_signed.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{JsonSchema, Schema};
 use alloc::borrow::Cow;
 use core::num::*;
@@ -17,8 +17,8 @@ macro_rules! nonzero_unsigned_impl {
                 stringify!(std::num::$type).into()
             }
 
-            fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-                let mut schema = <$primitive>::json_schema(gen);
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+                let mut schema = <$primitive>::json_schema(generator);
                 let object = schema.ensure_object();
                 object.insert("not".to_owned(), serde_json::json!({
                     "const": 0

--- a/schemars/src/json_schema_impls/nonzero_unsigned.rs
+++ b/schemars/src/json_schema_impls/nonzero_unsigned.rs
@@ -1,7 +1,7 @@
-use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::JsonSchema;
 use crate::Schema;
+use crate::SchemaGenerator;
+use crate::_alloc_prelude::*;
 use alloc::borrow::Cow;
 use core::num::*;
 
@@ -18,8 +18,8 @@ macro_rules! nonzero_unsigned_impl {
                 stringify!(std::num::$type).into()
             }
 
-            fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-                let mut schema = <$primitive>::json_schema(gen);
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+                let mut schema = <$primitive>::json_schema(generator);
                 let object = schema.ensure_object();
                 object.insert("minimum".to_owned(), 1.into());
                 schema

--- a/schemars/src/json_schema_impls/primitives.rs
+++ b/schemars/src/json_schema_impls/primitives.rs
@@ -1,5 +1,5 @@
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 

--- a/schemars/src/json_schema_impls/semver1.rs
+++ b/schemars/src/json_schema_impls/semver1.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use semver1::Version;

--- a/schemars/src/json_schema_impls/sequences.rs
+++ b/schemars/src/json_schema_impls/sequences.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 
@@ -19,10 +19,10 @@ macro_rules! seq_impl {
                 format!("[{}]", T::schema_id()).into()
             }
 
-            fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
                 json_schema!({
                     "type": "array",
-                    "items": gen.subschema_for::<T>(),
+                    "items": generator.subschema_for::<T>(),
                 })
             }
         }
@@ -45,11 +45,11 @@ macro_rules! set_impl {
                 format!("Set<{}>", T::schema_id()).into()
             }
 
-            fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
                 json_schema!({
                     "type": "array",
                     "uniqueItems": true,
-                    "items": gen.subschema_for::<T>(),
+                    "items": generator.subschema_for::<T>(),
                 })
             }
         }

--- a/schemars/src/json_schema_impls/serdejson.rs
+++ b/schemars/src/json_schema_impls/serdejson.rs
@@ -1,5 +1,5 @@
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use alloc::collections::BTreeMap;

--- a/schemars/src/json_schema_impls/std_time.rs
+++ b/schemars/src/json_schema_impls/std_time.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 
@@ -11,13 +11,13 @@ impl JsonSchema for core::time::Duration {
         "std::time::Duration".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "object",
             "required": ["secs", "nanos"],
             "properties": {
-                "secs": u64::json_schema(gen),
-                "nanos": u32::json_schema(gen),
+                "secs": u64::json_schema(generator),
+                "nanos": u32::json_schema(generator),
             }
         })
     }
@@ -33,13 +33,13 @@ impl JsonSchema for std::time::SystemTime {
         "std::time::SystemTime".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         json_schema!({
             "type": "object",
             "required": ["secs_since_epoch", "nanos_since_epoch"],
             "properties": {
-                "secs_since_epoch": u64::json_schema(gen),
-                "nanos_since_epoch": u32::json_schema(gen),
+                "secs_since_epoch": u64::json_schema(generator),
+                "nanos_since_epoch": u32::json_schema(generator),
             }
         })
     }

--- a/schemars/src/json_schema_impls/tuple.rs
+++ b/schemars/src/json_schema_impls/tuple.rs
@@ -1,5 +1,5 @@
+use crate::SchemaGenerator;
 use crate::_alloc_prelude::*;
-use crate::gen::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 
@@ -23,11 +23,11 @@ macro_rules! tuple_impls {
                     id.into()
                 }
 
-                fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+                fn json_schema(generator: &mut SchemaGenerator) -> Schema {
                     json_schema!({
                         "type": "array",
                         "prefixItems": [
-                            $(gen.subschema_for::<$name>()),+
+                            $(generator.subschema_for::<$name>()),+
                         ],
                         "minItems": $len,
                         "maxItems": $len,

--- a/schemars/src/json_schema_impls/url2.rs
+++ b/schemars/src/json_schema_impls/url2.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use url2::Url;

--- a/schemars/src/json_schema_impls/uuid1.rs
+++ b/schemars/src/json_schema_impls/uuid1.rs
@@ -1,4 +1,4 @@
-use crate::gen::SchemaGenerator;
+use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use uuid1::Uuid;

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -24,7 +24,7 @@ mod macros;
 /// outside of `schemars`, and should not be considered part of the public API.
 #[doc(hidden)]
 pub mod _private;
-pub mod gen;
+pub mod generate;
 pub mod transform;
 
 #[cfg(feature = "schemars_derive")]
@@ -40,7 +40,7 @@ pub extern crate alloc as _alloc;
 #[doc(hidden)]
 pub extern crate serde_json as _serde_json;
 
-pub use gen::SchemaGenerator;
+pub use generate::SchemaGenerator;
 pub use schema::Schema;
 
 mod _alloc_prelude {
@@ -50,6 +50,17 @@ mod _alloc_prelude {
     pub use alloc::string::{String, ToString};
     pub use alloc::vec;
     pub use alloc::vec::Vec;
+}
+
+#[deprecated = "Only included for backward-compatibility - use the `schemars::generate` module instead."]
+#[doc(hidden)]
+pub mod r#gen {
+    #[deprecated = "Only included for backward-compatibility - use `schemars::SchemaGenerator` or `schemars::generate::SchemaGenerator` instead."]
+    pub type SchemaGenerator = crate::generate::SchemaGenerator;
+    #[deprecated = "Only included for backward-compatibility - use `schemars::generate::SchemaSettings` instead."]
+    pub type SchemaSettings = crate::generate::SchemaSettings;
+    #[deprecated = "Only included for backward-compatibility - use `schemars::generate::GenTransform` instead."]
+    pub use crate::generate::GenTransform;
 }
 
 /// A type which can be described as a JSON Schema document.
@@ -166,12 +177,12 @@ pub trait JsonSchema {
     /// add them to the [`SchemaGenerator`]'s schema definitions.
     ///
     /// This should not return a `$ref` schema.
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema;
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema;
 
     // TODO document and bring into public API?
     #[doc(hidden)]
-    fn _schemars_private_non_optional_json_schema(gen: &mut SchemaGenerator) -> Schema {
-        Self::json_schema(gen)
+    fn _schemars_private_non_optional_json_schema(generator: &mut SchemaGenerator) -> Schema {
+        Self::json_schema(generator)
     }
 
     // TODO document and bring into public API?

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -242,7 +242,7 @@ impl crate::JsonSchema for Schema {
         "schemars::Schema".into()
     }
 
-    fn json_schema(_: &mut crate::gen::SchemaGenerator) -> Schema {
+    fn json_schema(_: &mut crate::SchemaGenerator) -> Schema {
         crate::json_schema!({
             "type": ["object", "boolean"]
         })

--- a/schemars/tests/docs.rs
+++ b/schemars/tests/docs.rs
@@ -1,5 +1,5 @@
 mod util;
-use schemars::{gen::SchemaSettings, JsonSchema};
+use schemars::{generate::SchemaSettings, JsonSchema};
 use util::*;
 
 #[allow(dead_code)]

--- a/schemars/tests/from_value.rs
+++ b/schemars/tests/from_value.rs
@@ -1,5 +1,5 @@
 mod util;
-use schemars::gen::{SchemaGenerator, SchemaSettings};
+use schemars::generate::{SchemaGenerator, SchemaSettings};
 use serde::Serialize;
 use std::collections::HashMap;
 use util::*;
@@ -53,32 +53,32 @@ fn make_value() -> MyStruct {
 
 #[test]
 fn schema_from_value_matches_draft07() -> TestResult {
-    let gen = SchemaSettings::draft07().into_generator();
-    let actual = gen.into_root_schema_for_value(&make_value())?;
+    let generator = SchemaSettings::draft07().into_generator();
+    let actual = generator.into_root_schema_for_value(&make_value())?;
 
     test_schema(&actual, "from_value_draft07")
 }
 
 #[test]
 fn schema_from_value_matches_2019_09() -> TestResult {
-    let gen = SchemaSettings::draft2019_09().into_generator();
-    let actual = gen.into_root_schema_for_value(&make_value())?;
+    let generator = SchemaSettings::draft2019_09().into_generator();
+    let actual = generator.into_root_schema_for_value(&make_value())?;
 
     test_schema(&actual, "from_value_2019_09")
 }
 
 #[test]
 fn schema_from_value_matches_openapi3() -> TestResult {
-    let gen = SchemaSettings::openapi3().into_generator();
-    let actual = gen.into_root_schema_for_value(&make_value())?;
+    let generator = SchemaSettings::openapi3().into_generator();
+    let actual = generator.into_root_schema_for_value(&make_value())?;
 
     test_schema(&actual, "from_value_openapi3")
 }
 
 #[test]
 fn schema_from_json_value() -> TestResult {
-    let gen = SchemaGenerator::default();
-    let actual = gen.into_root_schema_for_value(&serde_json::json!({
+    let generator = SchemaGenerator::default();
+    let actual = generator.into_root_schema_for_value(&serde_json::json!({
         "zero": 0,
         "one": 1,
         "minusOne": -1,

--- a/schemars/tests/inline_subschemas.rs
+++ b/schemars/tests/inline_subschemas.rs
@@ -1,5 +1,5 @@
 mod util;
-use schemars::gen::SchemaSettings;
+use schemars::generate::SchemaSettings;
 use schemars::JsonSchema;
 use util::*;
 

--- a/schemars/tests/schema_settings.rs
+++ b/schemars/tests/schema_settings.rs
@@ -1,5 +1,5 @@
 mod util;
-use schemars::gen::SchemaSettings;
+use schemars::generate::SchemaSettings;
 use schemars::{JsonSchema, Schema};
 use serde_json::Value;
 use std::collections::BTreeMap;

--- a/schemars/tests/schema_with_enum.rs
+++ b/schemars/tests/schema_with_enum.rs
@@ -2,8 +2,8 @@ mod util;
 use schemars::JsonSchema;
 use util::*;
 
-fn schema_fn(gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-    <bool>::json_schema(gen)
+fn schema_fn(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    <bool>::json_schema(generator)
 }
 
 #[derive(Debug)]

--- a/schemars/tests/schema_with_struct.rs
+++ b/schemars/tests/schema_with_struct.rs
@@ -2,8 +2,8 @@ mod util;
 use schemars::JsonSchema;
 use util::*;
 
-fn schema_fn(gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-    <bool>::json_schema(gen)
+fn schema_fn(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    <bool>::json_schema(generator)
 }
 
 struct DoesntImplementJsonSchema;

--- a/schemars/tests/util/mod.rs
+++ b/schemars/tests/util/mod.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use schemars::{gen::SchemaSettings, schema_for, JsonSchema, Schema};
+use schemars::{generate::SchemaSettings, schema_for, JsonSchema, Schema};
 use std::error::Error;
 use std::format;
 use std::fs;

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -68,12 +68,12 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                         <#ty as schemars::JsonSchema>::schema_id()
                     }
 
-                    fn json_schema(gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-                        <#ty as schemars::JsonSchema>::json_schema(gen)
+                    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                        <#ty as schemars::JsonSchema>::json_schema(generator)
                     }
 
-                    fn _schemars_private_non_optional_json_schema(gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-                        <#ty as schemars::JsonSchema>::_schemars_private_non_optional_json_schema(gen)
+                    fn _schemars_private_non_optional_json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                        <#ty as schemars::JsonSchema>::_schemars_private_non_optional_json_schema(generator)
                     }
 
                     fn _schemars_private_is_option() -> bool {
@@ -186,7 +186,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                     #schema_id
                 }
 
-                fn json_schema(gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+                fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
                     #schema_expr
                 }
             };


### PR DESCRIPTION
Fixes #306

`gen` is a reserved keyword in rust 2024, making it very awkward to use as a module/variable name.

This PR renames the `gen` module to `generate`, and all `gen` variables/params to `generator`. `gen` is still available as a module for backward-compatibility, but is marked as deprecated with a suggestion to use the new module name instead.

In #306, I suggested making `SchemaSettings` available at the crate root (i.e. as `schemars::SchemaSettings`), but I've since changed my mind. More types may be added to the `gen`/`generate` module in the future (e.g. [the "contract" proposal](https://github.com/GREsau/schemars/issues/48#issuecomment-2295283276)) - and I'm concerned that having to always put them at the crate root may make it very busy. Also, if schemars gets new features in the future (e.g. [validating values against schemas](https://github.com/GREsau/schemars/issues/309)), then these features may need their own settings, in which case having `schemars::SchemaSettings` apply only to schema generation would be confusing.