### PR TITLE
Read `#[garde(...)]` attributes in addition to `#[validate(...)]`

### DIFF
--- a/docs/0-migrating.md
+++ b/docs/0-migrating.md
@@ -173,3 +173,23 @@ fn my_transform2(schema: &mut Schema) {
 let mut schema = schemars::schema_for!(str);
 RecursiveTransform(my_transform2).transform(&mut schema);
 ```
+
+## Changes to `#[validate(...)]` attributes
+
+Since [adding support for `#[validate(...)]` attributes](https://graham.cool/schemars/v0/deriving/attributes/#supported-validator-attributes), the [Validator](https://github.com/Keats/validator) crate has made several changes to its supported attributes. Accordingly, Schemars 1.0 has updated its handling of `#[validate(...)]` attributes to match the latest version (currently 0.18.1) of the Validator crate - this removes some attributes, and changes the syntax of others:
+
+- The `#[validate(phone)]`/`#[schemars(phone)]` attribute is removed. If you want the old behaviour of setting the "format" property on the generated schema, you can use `#[schemars(extend("format = "phone"))]` instead.
+- The `#[validate(required_nested)]`/`#[schemars(required_nested)]` attribute is removed. If you want the old behaviour, you can use `#[schemars(required)]` instead.
+- The `#[validate(regex = "...")]`/`#[schemars(regex = "...")]` attribute can no longer use `name = "value"` syntax. Instead, you can use:
+
+  - `#[validate(regex(path = ...)]`
+  - `#[schemars(regex(pattern = ...)]`
+  - `#[schemars(pattern(...)]` (Garde-style)
+
+- Similarly, the `#[validate(contains = "...")]`/`#[schemars(contains = "...")]` attribute can no longer use `name = "value"` syntax. Instead, you can use:
+
+  - `#[validate(contains(pattern = ...))]`
+  - `#[schemars(contains(pattern = ...))]`
+  - `#[schemars(contains(...))]` (Garde-style)
+
+As an alternative option, Schemars 1.0 also adds support for `#[garde(...)]` attributes used with the [Garde](https://github.com/jprochazk/garde) crate, along with equivalent `#[schemars(...)]` attributes. See [the documentation](https://graham.cool/schemars/deriving/attributes/#supported-validatorgarde-attributes) for a list of all supported attributes.

--- a/docs/1.1-attributes.md
+++ b/docs/1.1-attributes.md
@@ -8,6 +8,7 @@ permalink: /deriving/attributes/
 <style>
 h3 code {
     font-weight: bold;
+    text-wrap: nowrap;
 }
 </style>
 

--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -246,8 +246,6 @@ Validator docs: [regex](https://github.com/Keats/validator#regex)
 
 For string schemas, sets the `pattern` property to the given value, with any regex special characters escaped.
 
-For object schemas (e.g. when the attribute is set on a HashMap field), includes the value in the `required` property, indicating that the map must contain it as a key. _N.B. this current object/map behaviour is present due to the previous behaviour of the Validator crate which has since been removed, so **may** also be removed from Schemars before the final 1.0 release._
-
 Validator docs: [contains](https://github.com/Keats/validator#contains)
 
 <h3 id="required">

--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -310,7 +310,7 @@ Set the path to the schemars crate instance the generated code should depend on.
 
 </h3>
 
-Sets properties specified by [validator attributes](#supported-validator-attributes) on items of an array schema. For example:
+Sets properties specified by [validator attributes](#supported-validatorgarde-attributes) on items of an array schema. For example:
 
 ```rust
 struct Struct {

--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -207,6 +207,8 @@ pub fn must_contain(schema: &mut Schema, contain: String) {
             .insert("pattern".to_owned(), pattern.into());
     }
 
+    // `#[validate(contains(...))]` working on map keys was removed from validator.
+    // Should we also remove this behaviour from schemars? Or keep it for back-compat?
     if schema.has_type("object") {
         if let Value::Array(array) = schema
             .ensure_object()

--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -199,28 +199,9 @@ pub fn insert_validation_property(
     }
 }
 
-pub fn must_contain(schema: &mut Schema, contain: String) {
-    if schema.has_type("string") {
-        let pattern = regex_syntax::escape(&contain);
-        schema
-            .ensure_object()
-            .insert("pattern".to_owned(), pattern.into());
-    }
-
-    // `#[validate(contains(...))]` working on map keys was removed from validator.
-    // Should we also remove this behaviour from schemars? Or keep it for back-compat?
-    if schema.has_type("object") {
-        if let Value::Array(array) = schema
-            .ensure_object()
-            .entry("required")
-            .or_insert(Value::Array(Vec::new()))
-        {
-            let value = Value::from(contain);
-            if !array.contains(&value) {
-                array.push(value);
-            }
-        }
-    }
+pub fn must_contain(schema: &mut Schema, substring: &str) {
+    let escaped = regex_syntax::escape(substring);
+    insert_validation_property(schema, "string", "pattern", escaped);
 }
 
 pub fn apply_inner_validation(schema: &mut Schema, f: fn(&mut Schema) -> ()) {

--- a/schemars/tests/expected/garde.json
+++ b/schemars/tests/expected/garde.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object",
+  "properties": {
+    "min_max": {
+      "type": "number",
+      "format": "float",
+      "minimum": 0.01,
+      "maximum": 100
+    },
+    "min_max2": {
+      "type": "number",
+      "format": "float",
+      "minimum": 1,
+      "maximum": 1000
+    },
+    "regex_str1": {
+      "type": "string",
+      "pattern": "^[Hh]ello\\b"
+    },
+    "contains_str1": {
+      "type": "string",
+      "pattern": "substring\\.\\.\\."
+    },
+    "email_address": {
+      "type": "string",
+      "format": "email"
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "non_empty_str": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "non_empty_str2": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "pair": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "required_option": {
+      "type": "boolean"
+    },
+    "x": {
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "required": [
+    "min_max",
+    "min_max2",
+    "regex_str1",
+    "contains_str1",
+    "email_address",
+    "homepage",
+    "non_empty_str",
+    "non_empty_str2",
+    "pair",
+    "required_option",
+    "x"
+  ]
+}

--- a/schemars/tests/expected/garde_newtype.json
+++ b/schemars/tests/expected/garde_newtype.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NewType",
+  "type": "integer",
+  "format": "uint8",
+  "minimum": 0,
+  "maximum": 10
+}

--- a/schemars/tests/expected/garde_schemars_attrs.json
+++ b/schemars/tests/expected/garde_schemars_attrs.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct2",
+  "type": "object",
+  "properties": {
+    "min_max": {
+      "type": "number",
+      "format": "float",
+      "minimum": 0.01,
+      "maximum": 100
+    },
+    "min_max2": {
+      "type": "number",
+      "format": "float",
+      "minimum": 1,
+      "maximum": 1000
+    },
+    "regex_str1": {
+      "type": "string",
+      "pattern": "^[Hh]ello\\b"
+    },
+    "contains_str1": {
+      "type": "string",
+      "pattern": "substring\\.\\.\\."
+    },
+    "email_address": {
+      "type": "string",
+      "format": "email"
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "non_empty_str": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "non_empty_str2": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "pair": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "required_option": {
+      "type": "boolean"
+    },
+    "x": {
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "required": [
+    "min_max",
+    "min_max2",
+    "regex_str1",
+    "contains_str1",
+    "email_address",
+    "homepage",
+    "non_empty_str",
+    "non_empty_str2",
+    "pair",
+    "required_option",
+    "x"
+  ]
+}

--- a/schemars/tests/expected/garde_tuple.json
+++ b/schemars/tests/expected/garde_tuple.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Tuple",
+  "type": "array",
+  "prefixItems": [
+    {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0,
+      "maximum": 10
+    },
+    {
+      "type": "boolean"
+    }
+  ],
+  "minItems": 2,
+  "maxItems": 2
+}

--- a/schemars/tests/expected/validate.json
+++ b/schemars/tests/expected/validate.json
@@ -58,15 +58,6 @@
       "minItems": 2,
       "maxItems": 2
     },
-    "map_contains": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "null"
-      },
-      "required": [
-        "map_key"
-      ]
-    },
     "required_option": {
       "type": "boolean"
     },
@@ -87,7 +78,6 @@
     "non_empty_str",
     "non_empty_str2",
     "pair",
-    "map_contains",
     "required_option",
     "x"
   ]

--- a/schemars/tests/expected/validate_schemars_attrs.json
+++ b/schemars/tests/expected/validate_schemars_attrs.json
@@ -58,15 +58,6 @@
       "minItems": 2,
       "maxItems": 2
     },
-    "map_contains": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "null"
-      },
-      "required": [
-        "map_key"
-      ]
-    },
     "required_option": {
       "type": "boolean"
     },
@@ -87,7 +78,6 @@
     "non_empty_str",
     "non_empty_str2",
     "pair",
-    "map_contains",
     "required_option",
     "x"
   ]

--- a/schemars/tests/garde.rs
+++ b/schemars/tests/garde.rs
@@ -1,0 +1,99 @@
+mod util;
+use schemars::JsonSchema;
+use util::*;
+
+const MIN: u32 = 1;
+const MAX: u32 = 1000;
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct Struct {
+    #[garde(range(min = 0.01, max = 100))]
+    min_max: f32,
+    #[garde(range(min = MIN, max = MAX))]
+    min_max2: f32,
+    #[garde(pattern(r"^[Hh]ello\b"))]
+    regex_str1: String,
+    #[garde(contains(concat!("sub","string...")))]
+    contains_str1: String,
+    #[garde(email)]
+    email_address: String,
+    #[garde(url)]
+    homepage: String,
+    #[garde(length(min = 1, max = 100))]
+    non_empty_str: String,
+    #[garde(length(min = MIN, max = MAX))]
+    non_empty_str2: String,
+    #[garde(length(equal = 2))]
+    pair: Vec<i32>,
+    #[garde(required)]
+    required_option: Option<bool>,
+    #[garde(required)]
+    #[serde(flatten)]
+    required_flattened: Option<Inner>,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct Inner {
+    x: i32,
+}
+
+#[test]
+fn garde() -> TestResult {
+    test_default_generated_schema::<Struct>("garde")
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct Struct2 {
+    #[schemars(range(min = 0.01, max = 100))]
+    min_max: f32,
+    #[schemars(range(min = MIN, max = MAX))]
+    min_max2: f32,
+    #[schemars(pattern(r"^[Hh]ello\b"))]
+    regex_str1: String,
+    #[schemars(contains(concat!("sub","string...")))]
+    contains_str1: String,
+    #[schemars(email)]
+    email_address: String,
+    #[schemars(url)]
+    homepage: String,
+    #[schemars(length(min = 1, max = 100))]
+    non_empty_str: String,
+    #[schemars(length(min = MIN, max = MAX))]
+    non_empty_str2: String,
+    #[schemars(length(equal = 2))]
+    pair: Vec<i32>,
+    #[schemars(required)]
+    required_option: Option<bool>,
+    #[schemars(required)]
+    #[serde(flatten)]
+    required_flattened: Option<Inner>,
+}
+
+#[test]
+fn garde_schemars_attrs() -> TestResult {
+    test_default_generated_schema::<Struct2>("garde_schemars_attrs")
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct Tuple(
+    #[garde(range(max = 10))] u8,
+    #[garde(required)] Option<bool>,
+);
+
+#[test]
+fn garde_tuple() -> TestResult {
+    test_default_generated_schema::<Tuple>("garde_tuple")
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct NewType(#[garde(range(max = 10))] u8);
+
+#[test]
+fn garde_newtype() -> TestResult {
+    test_default_generated_schema::<NewType>("garde_newtype")
+}

--- a/schemars/tests/validate.rs
+++ b/schemars/tests/validate.rs
@@ -1,6 +1,5 @@
 mod util;
 use schemars::JsonSchema;
-use std::collections::BTreeMap;
 use util::*;
 
 struct FakeRegex(&'static str);
@@ -42,8 +41,6 @@ pub struct Struct {
     non_empty_str2: String,
     #[validate(length(equal = 2))]
     pair: Vec<i32>,
-    #[validate(contains(pattern = "map_key"))]
-    map_contains: BTreeMap<String, ()>,
     #[validate(required)]
     required_option: Option<bool>,
     #[validate(required)]
@@ -90,8 +87,6 @@ pub struct Struct2 {
     non_empty_str2: String,
     #[schemars(length(equal = 2))]
     pair: Vec<i32>,
-    #[schemars(contains(pattern = "map_key"))]
-    map_contains: BTreeMap<String, ()>,
     #[schemars(required)]
     required_option: Option<bool>,
     #[schemars(required)]

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -278,6 +278,7 @@ impl ContainerAttrs {
                 None => self.crate_name = parse_name_value_lit_str(meta, cx).ok(),
             },
 
+            // The actual parsing of `rename` is done by serde
             "rename" => self.is_renamed = true,
 
             _ => return Some(meta),

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -210,9 +210,10 @@ impl FieldAttrs {
         let schemars_cx = &mut AttrCtxt::new(cx, attrs, "schemars");
         let serde_cx = &mut AttrCtxt::new(cx, attrs, "serde");
         let validate_cx = &mut AttrCtxt::new(cx, attrs, "validate");
+        let garde_cx = &mut AttrCtxt::new(cx, attrs, "garde");
 
         self.common.populate(attrs, schemars_cx, serde_cx);
-        self.validation.populate(schemars_cx, validate_cx);
+        self.validation.populate(schemars_cx, validate_cx, garde_cx);
         self.process_attr(schemars_cx);
         self.process_attr(serde_cx);
     }

--- a/schemars_derive/src/attr/validation.rs
+++ b/schemars_derive/src/attr/validation.rs
@@ -88,7 +88,7 @@ impl ValidationAttrs {
 
         if let Some(contains) = &self.contains {
             mutators.push(quote! {
-                schemars::_private::must_contain(#mut_ref_schema, #contains.to_string());
+                schemars::_private::must_contain(#mut_ref_schema, &#contains.to_string());
             });
         }
 

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -18,7 +18,7 @@ use syn::spanned::Spanned;
 
 #[doc = "Derive macro for `JsonSchema` trait."]
 #[cfg_attr(not(doctest), doc = include_str!("../deriving.md"), doc = include_str!("../attributes.md"))]
-#[proc_macro_derive(JsonSchema, attributes(schemars, serde, validate))]
+#[proc_macro_derive(JsonSchema, attributes(schemars, serde, validate, garde))]
 pub fn derive_json_schema_wrapper(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     derive_json_schema(input, false)


### PR DESCRIPTION
Addresses #233

Add support for the following [garde](https://github.com/jprochazk/garde) attributes, along with allowing `#[schemars(...)]` overrides:
- `required`
- `email`
- `url`
- `ip`/`ipv4`/`ipv6`
- `length`
- `range`
- `contains`
- `pattern`
- `inner`

Does **not** support:
- `ascii`
- `alphanumeric`
- `prefix`/`suffix`
- `credit_card`
- `phone_number`
- `matches`
- `div`
- `skip`
- `custom`