### PR TITLE
chore: Update jsonschema to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be7aa9f08a262039c0b5eb11b792e4353dad5263f78e33312b7ba9e43b32ae9"
+checksum = "f2eef4e82b548e08ac880d307c8e8838b45f497a08d3202f3b26c9debaed8058"
 dependencies = [
  "ahash",
  "anyhow",

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -37,7 +37,7 @@ uuid1 = { version = "1.0", default-features = false, optional = true, package = 
 pretty_assertions = "1.2.1"
 trybuild = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-jsonschema = { version = "0.19.0", default-features = false }
+jsonschema = { version = "0.20", default-features = false }
 snapbox = { version = "0.6.17", features = ["json"] }
 serde_repr = "0.1.19"
 # Use github source until published garde version supports `length(equal = ...)` attr


### PR DESCRIPTION
I've been updating the public API in `jsonschema` and I am here to update the version & add usage of the new API instead of the deprecated one. 