### PR TITLE
Improve handling of internally tagged enum with newtypes

### DIFF
--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -22,8 +22,11 @@
           "const": "StringMap"
         }
       },
-      "additionalProperties": {
-        "type": "string"
+      "allOf": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "required": [
         "tag"
@@ -37,6 +40,9 @@
           "const": "UnitStructNewType"
         }
       },
+      "allOf": {
+        "$ref": "#/$defs/UnitStruct"
+      },
       "required": [
         "tag"
       ]
@@ -44,22 +50,16 @@
     {
       "type": "object",
       "properties": {
-        "foo": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "bar": {
-          "type": "boolean"
-        },
         "tag": {
           "type": "string",
           "const": "StructNewType"
         }
       },
+      "allOf": {
+        "$ref": "#/$defs/Struct"
+      },
       "required": [
-        "tag",
-        "foo",
-        "bar"
+        "tag"
       ]
     },
     {
@@ -95,5 +95,26 @@
         "tag"
       ]
     }
-  ]
+  ],
+  "$defs": {
+    "UnitStruct": {
+      "type": "null"
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    }
+  }
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -22,12 +22,14 @@
           "const": "StringMap"
         }
       },
-      "allOf": [{
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
+      "allOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      }],
+      ],
       "required": [
         "tag"
       ]
@@ -40,9 +42,11 @@
           "const": "UnitStructNewType"
         }
       },
-      "allOf": [{
-        "$ref": "#/$defs/UnitStruct"
-      }],
+      "allOf": [
+        {
+          "$ref": "#/$defs/UnitStruct"
+        }
+      ],
       "required": [
         "tag"
       ]
@@ -55,9 +59,11 @@
           "const": "StructNewType"
         }
       },
-      "allOf": [{
-        "$ref": "#/$defs/Struct"
-      }],
+      "allOf": [
+        {
+          "$ref": "#/$defs/Struct"
+        }
+      ],
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -98,9 +98,6 @@
     }
   ],
   "$defs": {
-    "UnitStruct": {
-      "type": "null"
-    },
     "Struct": {
       "type": "object",
       "properties": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -42,11 +42,6 @@
           "const": "UnitStructNewType"
         }
       },
-      "allOf": [
-        {
-          "$ref": "#/$defs/UnitStruct"
-        }
-      ],
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -22,12 +22,12 @@
           "const": "StringMap"
         }
       },
-      "allOf": {
+      "allOf": [{
         "type": "object",
         "additionalProperties": {
           "type": "string"
         }
-      },
+      }],
       "required": [
         "tag"
       ]
@@ -40,9 +40,9 @@
           "const": "UnitStructNewType"
         }
       },
-      "allOf": {
+      "allOf": [{
         "$ref": "#/$defs/UnitStruct"
-      },
+      }],
       "required": [
         "tag"
       ]
@@ -55,9 +55,9 @@
           "const": "StructNewType"
         }
       },
-      "allOf": {
+      "allOf": [{
         "$ref": "#/$defs/Struct"
-      },
+      }],
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
@@ -23,12 +23,14 @@
           "const": "StringMap"
         }
       },
-      "allOf": [{
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
+      "allOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      }],
+      ],
       "required": [
         "tag"
       ]
@@ -41,9 +43,11 @@
           "const": "StructNewType"
         }
       },
-      "allOf": [{
-        "$ref": "#/$defs/Struct"
-      }],
+      "allOf": [
+        {
+          "$ref": "#/$defs/Struct"
+        }
+      ],
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
@@ -23,12 +23,12 @@
           "const": "StringMap"
         }
       },
-      "allOf": {
+      "allOf": [{
         "type": "object",
         "additionalProperties": {
           "type": "string"
         }
-      },
+      }],
       "required": [
         "tag"
       ]
@@ -41,9 +41,9 @@
           "const": "StructNewType"
         }
       },
-      "allOf": {
+      "allOf": [{
         "$ref": "#/$defs/Struct"
-      },
+      }],
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
@@ -23,8 +23,11 @@
           "const": "StringMap"
         }
       },
-      "additionalProperties": {
-        "type": "string"
+      "allOf": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "required": [
         "tag"
@@ -33,22 +36,16 @@
     {
       "type": "object",
       "properties": {
-        "foo": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "bar": {
-          "type": "boolean"
-        },
         "tag": {
           "type": "string",
           "const": "StructNewType"
         }
       },
+      "allOf": {
+        "$ref": "#/$defs/Struct"
+      },
       "required": [
-        "tag",
-        "foo",
-        "bar"
+        "tag"
       ]
     },
     {
@@ -73,5 +70,23 @@
         "bar"
       ]
     }
-  ]
+  ],
+  "$defs": {
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    }
+  }
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,6 +23,7 @@
           "const": "NewType"
         }
       },
+      "allOf": "true",
       "required": [
         "t"
       ],

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,9 +23,6 @@
           "const": "NewType"
         }
       },
-      "allOf": [
-        true
-      ],
       "required": [
         "t"
       ],

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,7 +23,7 @@
           "const": "NewType"
         }
       },
-      "allOf": "true",
+      "allOf": true,
       "required": [
         "t"
       ],

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,7 +23,7 @@
           "const": "NewType"
         }
       },
-      "allOf": true,
+      "allOf": [true],
       "required": [
         "t"
       ],

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,7 +23,9 @@
           "const": "NewType"
         }
       },
-      "allOf": [true],
+      "allOf": [
+        true
+      ],
       "required": [
         "t"
       ],

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_internally_tagged_enum.json
@@ -23,6 +23,9 @@
           "const": "NewType"
         }
       },
+      "allOf": [
+        true
+      ],
       "required": [
         "t"
       ],

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -154,7 +154,12 @@ fn expr_for_internally_tagged_newtype_field(field: &Field) -> SchemaExpr {
                     let mut map = schemars::_private::serde_json::Map::new();
                     map.insert(
                         #keyword.into(),
-                        #GENERATOR.subschema_for::<#ty>().to_value()
+                        schemars::_private::serde_json::Value::Array({
+                            let mut enum_values = schemars::_private::alloc::vec::Vec::new();
+                            enum_values.push(#GENERATOR.subschema_for::<#ty>().to_value());
+                            enum_values
+                        }),
+                        
                     );
                     schemars::Schema::from(map)
                 }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -152,9 +152,8 @@ fn expr_for_internally_tagged_newtype_field(field: &Field) -> SchemaExpr {
                     <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
                 } else {
                     let subschema = <#ty as schemars::JsonSchema>::json_schema(#GENERATOR);
-                    dbg!();
                     if let Some(type_val) = subschema.get("type") {
-                        if (type_val.as_str().unwrap() != "None") {
+                        if (type_val.as_str().unwrap() != "null") {
                             let mut map = schemars::_private::serde_json::Map::new();
                             map.insert(
                                 #keyword.into(),

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -152,22 +152,20 @@ fn expr_for_internally_tagged_newtype_field(field: &Field) -> SchemaExpr {
                     <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
                 } else {
                     let subschema = <#ty as schemars::JsonSchema>::json_schema(#GENERATOR);
-                    if let Some(type_val) = subschema.get("type") {
-                        if (type_val.as_str().unwrap() != "null") {
-                            let mut map = schemars::_private::serde_json::Map::new();
-                            map.insert(
-                                #keyword.into(),
-                                schemars::_private::serde_json::Value::Array({
-                                    let mut enum_values = schemars::_private::alloc::vec::Vec::new();
-                                    enum_values.push(#GENERATOR.subschema_for::<#ty>().to_value());
-                                    enum_values
-                                }),
-                                
-                            );
-                            schemars::Schema::from(map)
-                        } else {
-                            <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
-                        }
+                    let subschema_type = subschema.get("type");
+                    let is_null_type = subschema_type.is_some() && subschema_type.unwrap().as_str().unwrap() == "null";
+                    if !is_null_type {
+                        let mut map = schemars::_private::serde_json::Map::new();
+                        map.insert(
+                            #keyword.into(),
+                            schemars::_private::serde_json::Value::Array({
+                                let mut enum_values = schemars::_private::alloc::vec::Vec::new();
+                                enum_values.push(#GENERATOR.subschema_for::<#ty>().to_value());
+                                enum_values
+                            }),
+                            
+                        );
+                        schemars::Schema::from(map)
                     } else  {
                         <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
                     }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -151,17 +151,27 @@ fn expr_for_internally_tagged_newtype_field(field: &Field) -> SchemaExpr {
                 if (#GENERATOR.settings().inline_subschemas) {
                     <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
                 } else {
-                    let mut map = schemars::_private::serde_json::Map::new();
-                    map.insert(
-                        #keyword.into(),
-                        schemars::_private::serde_json::Value::Array({
-                            let mut enum_values = schemars::_private::alloc::vec::Vec::new();
-                            enum_values.push(#GENERATOR.subschema_for::<#ty>().to_value());
-                            enum_values
-                        }),
-                        
-                    );
-                    schemars::Schema::from(map)
+                    let subschema = <#ty as schemars::JsonSchema>::json_schema(#GENERATOR);
+                    dbg!();
+                    if let Some(type_val) = subschema.get("type") {
+                        if (type_val.as_str().unwrap() != "None") {
+                            let mut map = schemars::_private::serde_json::Map::new();
+                            map.insert(
+                                #keyword.into(),
+                                schemars::_private::serde_json::Value::Array({
+                                    let mut enum_values = schemars::_private::alloc::vec::Vec::new();
+                                    enum_values.push(#GENERATOR.subschema_for::<#ty>().to_value());
+                                    enum_values
+                                }),
+                                
+                            );
+                            schemars::Schema::from(map)
+                        } else {
+                            <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
+                        }
+                    } else  {
+                        <#ty as schemars::JsonSchema>::json_schema(#GENERATOR)
+                    }
                 }
             }
         )

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -298,10 +298,10 @@ fn expr_for_internal_tagged_enum<'a>(
 ) -> SchemaExpr {
     let variant_schemas = variants
         .map(|variant| {
+
             let mut schema_expr = expr_for_internal_tagged_enum_variant(variant, deny_unknown_fields);
 
             let name = variant.name();
-
             schema_expr.mutators.push(quote!(
                 schemars::_private::apply_internal_enum_variant_tag(&mut #SCHEMA, #tag_name, #name, #deny_unknown_fields);
             ));


### PR DESCRIPTION
Right now Schemar's behavior for Internally tagged enums, while valid, is lossy and generates schemas that I have found cause some problems in practice.

Effectively, it always generates a schema that inline's subschemas creating potentially deeply nested schemas. For example, the following rust code:

```RUST
use schemars::{generate::SchemaSettings, schema_for, JsonSchema};

#[derive(JsonSchema)]
#[serde(tag = "type")]
enum Root {
    A(SubEnum1),
    B(SubEnum2),
}

#[derive(JsonSchema)]
#[serde(tag = "other_type")]
enum SubEnum1 {
    C(SubSchema1),
    D(SubSchema2),
}

#[derive(JsonSchema)]
#[serde(tag = "other_type")]
enum SubEnum2 {
    E(SubSchema3),
    F(SubSchema4),
    G(String),
    H{id: String}
}

#[derive(JsonSchema)]
struct SubSchema1 {
    w: String,
}

#[derive(JsonSchema)]
struct SubSchema2 {
    x: String,
}

#[derive(JsonSchema)]
struct SubSchema3 {
    y: String,
}

#[derive(JsonSchema)]
struct SubSchema4 {
    z: String,
}
```
Currently generates the schema:

```JSON
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Root",
  "oneOf": [
    {
      "type": "object",
      "properties": {
        "type": {
          "type": "string",
          "const": "A"
        }
      },
      "oneOf": [
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "C"
            },
            "w": {
              "type": "string"
            }
          },
          "required": [
            "other_type",
            "w"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "D"
            },
            "x": {
              "type": "string"
            }
          },
          "required": [
            "other_type",
            "x"
          ]
        }
      ],
      "required": [
        "type"
      ]
    },
    {
      "type": "object",
      "properties": {
        "type": {
          "type": "string",
          "const": "B"
        }
      },
      "oneOf": [
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "E"
            },
            "y": {
              "type": "string"
            }
          },
          "required": [
            "other_type",
            "y"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "F"
            },
            "z": {
              "type": "string"
            }
          },
          "required": [
            "other_type",
            "z"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "G"
            }
          },
          "required": [
            "other_type"
          ]
        },
        {
          "type": "object",
          "properties": {
            "id": {
              "type": "string"
            },
            "other_type": {
              "type": "string",
              "const": "H"
            }
          },
          "required": [
            "other_type",
            "id"
          ]
        }
      ],
      "required": [
        "type"
      ]
    }
  ]
}
```
In this schema, all the types except for Root are not explicitly listed and it's Impossible to access any of the subschemas directly. Especially if I want to use JsonSchema to share these models with another language, generating a deeply nested schema like this makes it complicated to reuse.

This PR updates the logic for internally tagged enum NewType variants so that if the user provides the setting `inline_subschemas` is true. Rather than inlining the subschema, it generates a schema that looks like this:
```JSON
{
  "allOf": [{
     "$ref": "{path to subschema}"
  }],
  "properties": {
     "{tagField}": {
        "type": "string",
        "const": "{tagValue}"
     }
  },
  "required": [
    "{tagField}"
  ]
}
```
This new schema uses JsonSchemas [allOf](https://json-schema.org/understanding-json-schema/reference/combining#allOf) field to say that the actual type is the subschemas type and the tag field. This allows the resulting schema to be functionally equivalent but rather reference the existing type rather than inlining it.

For the sample above, the new resulting schema:
```JSON
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Root",
  "oneOf": [
    {
      "type": "object",
      "properties": {
        "type": {
          "type": "string",
          "const": "A"
        }
      },
      "allOf": [
        {
          "$ref": "#/$defs/SubEnum1"
        }
      ],
      "required": [
        "type"
      ]
    },
    {
      "type": "object",
      "properties": {
        "type": {
          "type": "string",
          "const": "B"
        }
      },
      "allOf": [
        {
          "$ref": "#/$defs/SubEnum2"
        }
      ],
      "required": [
        "type"
      ]
    }
  ],
  "$defs": {
    "SubEnum1": {
      "oneOf": [
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "C"
            }
          },
          "allOf": [
            {
              "$ref": "#/$defs/SubSchema1"
            }
          ],
          "required": [
            "other_type"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "D"
            }
          },
          "allOf": [
            {
              "$ref": "#/$defs/SubSchema2"
            }
          ],
          "required": [
            "other_type"
          ]
        }
      ]
    },
    "SubEnum2": {
      "oneOf": [
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "E"
            }
          },
          "allOf": [
            {
              "$ref": "#/$defs/SubSchema3"
            }
          ],
          "required": [
            "other_type"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "F"
            }
          },
          "allOf": [
            {
              "$ref": "#/$defs/SubSchema4"
            }
          ],
          "required": [
            "other_type"
          ]
        },
        {
          "type": "object",
          "properties": {
            "other_type": {
              "type": "string",
              "const": "G"
            }
          },
          "allOf": [
            {
              "type": "string"
            }
          ],
          "required": [
            "other_type"
          ]
        },
        {
          "type": "object",
          "properties": {
            "id": {
              "type": "string"
            },
            "other_type": {
              "type": "string",
              "const": "H"
            }
          },
          "required": [
            "other_type",
            "id"
          ]
        }
      ]
    },
    "SubSchema1": {
      "type": "object",
      "properties": {
        "w": {
          "type": "string"
        }
      },
      "required": [
        "w"
      ]
    },
    "SubSchema2": {
      "type": "object",
      "properties": {
        "x": {
          "type": "string"
        }
      },
      "required": [
        "x"
      ]
    },
    "SubSchema3": {
      "type": "object",
      "properties": {
        "y": {
          "type": "string"
        }
      },
      "required": [
        "y"
      ]
    },
    "SubSchema4": {
      "type": "object",
      "properties": {
        "z": {
          "type": "string"
        }
      },
      "required": [
        "z"
      ]
    }
  }
}
```
This resulting schema includes all the subtypes and the enum schemas are able to just reference the other definitions.


