### PR TITLE
add feature for serde_bytes::ByteBuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "schemars_derive",
  "semver",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serde_repr",
  "smallvec",
@@ -833,6 +834,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -32,6 +32,7 @@ smallvec1 = { version = "1.0", default-features = false, optional = true, packag
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+serde_bytes = { version = "0.11.12", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -76,12 +77,18 @@ preserve_order  = ["serde_json/preserve_order"]
 # Implements `JsonSchema` on `serde_json::value::RawValue`
 raw_value = ["serde_json/raw_value"]
 
+serde_bytes = ["dep:serde_bytes"]
+
 # For internal/CI use only
 _ui_test = []
 
 [[test]]
 name = "ui"
 required-features = ["_ui_test"]
+
+[[test]]
+name = "serde_bytes"
+required-features = ["serde_bytes"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -45,6 +45,8 @@ mod maps;
 mod nonzero;
 mod primitives;
 mod sequences;
+#[cfg(feature = "serde_bytes")]
+mod serde_bytes;
 mod serdejson;
 mod std_time;
 mod tuple;

--- a/schemars/src/json_schema_impls/serde_bytes.rs
+++ b/schemars/src/json_schema_impls/serde_bytes.rs
@@ -1,0 +1,11 @@
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use serde_bytes::ByteBuf;
+
+forward_impl!((JsonSchema for ByteBuf) => Vec<u8>);
+// Because Bytes is a wrapper around [u8] which is not `Sized`
+// I couldn't get it through the testsuite to check if this actually works.
+//
+// use serde_bytes::Bytes;
+// forward_impl!((JsonSchema for Bytes) => Vec<u8>);

--- a/schemars/tests/serde_bytes.rs
+++ b/schemars/tests/serde_bytes.rs
@@ -1,0 +1,8 @@
+mod util;
+use serde_bytes::ByteBuf;
+use util::*;
+
+#[test]
+fn bytes() -> TestResult {
+    test_default_generated_schema::<(ByteBuf, ByteBuf)>("bytes")
+}


### PR DESCRIPTION
Rebasing PR #252 on top of master, because the original PR wasn't made from a feature branch, it was easier to just open a new PR (and there was no substantial discussion lost).

Although it has been a while, I'm still interested in this patch for use in the linebender peniko crate.
Other linebender crates (kurbo) support schemars, but `serde_bytes` support is needed for peniko.
Supporting it there would currently allow some cleanups to CI in https://github.com/linebender/vello/pull/733

`serde_bytes` being a dtolnay making it somewhat part of the serde ecosystem so at least from my perspective
this is a good argument for supporting the crate.