### PR TITLE
Allow `example` attribute value to be any expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 - the `enumset1`/`enumset` optional dependency has been removed, as its `JsonSchema` impl did not actually match the default serialization format of `EnumSet` (https://github.com/GREsau/schemars/pull/339)
 
-### Changed
+### Changed (_⚠️ breaking changes ⚠️_)
 
-- ⚠️ MSRV is now 1.70 ⚠️
+- MSRV is now 1.70
+- [The `example` attribute](https://graham.cool/schemars/deriving/attributes/#example) value is now an arbitrary expression, rather than a string literal identifying a function to call. To avoid silent behaviour changes, the expression must not be a string literal where the value can be parsed as a function path - e.g. `#[schemars(example = "foo")]` is now a compile error, but `#[schemars(example = foo())]` is allowed (as is `#[schemars(example = &"foo")]` if you want the the literal string value `"foo"` to be the example).
 
 ### Fixed
 

--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -298,13 +298,15 @@ Set on a container, variant or field to set the generated schema's `title` and/o
 
 <h3 id="example">
 
-`#[schemars(example = "some::function")]`
+`#[schemars(example = value)]`
 
 </h3>
 
-Set on a container, variant or field to include the result of the given function in the generated schema's `examples`. The function should take no parameters and can return any type that implements serde's `Serialize` trait - it does not need to return the same type as the attached struct/field. This attribute can be repeated to specify multiple examples.
+Set on a container, variant or field to include the given value in the generated schema's `examples`. The value can be any type that implements serde's `Serialize` trait - it does not need to be the same type as the attached struct/field. This attribute can be repeated to specify multiple examples.
 
-To use the result of arbitrary expressions as examples, you can instead use the [`extend`](#extend) attribute, e.g. `[schemars(extend("examples" = ["example string"]))]`.
+In previous versions of schemars, the value had to be a string literal identifying a defined function that would be called to return the actual example value (similar to the [`default`](#default) attribute). To avoid the new attribute behaviour from silently breaking old consumers, string literals consisting of a single word (e.g. `#[schemars(example = "my_fn")]`) or a path (e.g. `#[schemars(example = "my_mod::my_fn")]`) are currently disallowed. This restriction may be relaxed in a future version of schemars, but for now if you want to include such a string as the literal example value, this can be done by borrowing the value, e.g. `#[schemars(example = &"my_fn")]`. If you instead want to call a function to get the example value (mirrorring the old behaviour), you must use an explicit function call expression, e.g. `#[schemars(example = my_fn())]`.
+
+Alternatively, to directly set multiple examples without repeating `example = ...` attribute, you can instead use the [`extend`](#extend) attribute, e.g. `#[schemars(extend("examples" = [1, 2, 3]))]`.
 
 <h3 id="deprecated">
 

--- a/schemars/tests/integration/examples.rs
+++ b/schemars/tests/integration/examples.rs
@@ -1,20 +1,14 @@
 use crate::prelude::*;
 
 #[derive(Default, JsonSchema, Serialize)]
-#[schemars(example = "Struct::default", example = "null")]
+#[schemars(example = Struct::default(), example = ())]
 struct Struct {
-    #[schemars(example = "eight", example = "null")]
+    #[schemars(example = 4 + 4, example = ())]
     foo: i32,
     bar: bool,
-    #[schemars(example = "null")]
+    #[schemars(example = (), example = &"foo")]
     baz: Option<&'static str>,
 }
-
-fn eight() -> i32 {
-    8
-}
-
-fn null() {}
 
 #[test]
 fn examples() {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/examples.rs~examples.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/examples.rs~examples.de.json
@@ -20,7 +20,8 @@
         "null"
       ],
       "examples": [
-        null
+        null,
+        "foo"
       ]
     }
   },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/examples.rs~examples.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/examples.rs~examples.ser.json
@@ -20,7 +20,8 @@
         "null"
       ],
       "examples": [
-        null
+        null,
+        "foo"
       ]
     }
   },

--- a/schemars/tests/ui/example_fn.rs
+++ b/schemars/tests/ui/example_fn.rs
@@ -1,0 +1,9 @@
+use schemars::JsonSchema;
+
+#[derive(JsonSchema)]
+#[schemars(example = "my_fn")]
+pub struct Struct;
+
+fn my_fn() {}
+
+fn main() {}

--- a/schemars/tests/ui/example_fn.stderr
+++ b/schemars/tests/ui/example_fn.stderr
@@ -1,0 +1,7 @@
+error: `example` value must be an expression, and string literals that may be interpreted as function paths are currently disallowed to avoid migration errors (this restriction may be relaxed in a future version of schemars).
+       If you want to use the result of a function, use `#[schemars(example = my_fn())]`.
+       Or to use the string literal value, use `#[schemars(example = &"my_fn")]`.
+ --> tests/ui/example_fn.rs:4:22
+  |
+4 | #[schemars(example = "my_fn")]
+  |                      ^^^^^^^

--- a/schemars/tests/ui/transform_str.stderr
+++ b/schemars/tests/ui/transform_str.stderr
@@ -1,5 +1,5 @@
 error: Expected a `fn(&mut Schema)` or other value implementing `schemars::transform::Transform`, found `&str`.
-       Did you mean `[schemars(transform = x)]`?
+       Did you mean `#[schemars(transform = x)]`?
  --> tests/ui/transform_str.rs:4:24
   |
 4 | #[schemars(transform = "x")]


### PR DESCRIPTION
```rust
#[schemars(example = 0.1)]
n: f32,
#[schemars(example = "example value", example = a_second_example())]
s: String,
```

Currently, the `example` attribute mirrors serde's `default` attribute, in that its value must be a string literal identifying a function to call. This requires consumers to define a function that usually just returns a constant value, which is really just boilerplate. "Default literals" is a popular feature request for serde (https://github.com/serde-rs/serde/issues/368), although it's a bit awkward to implement cleanly due to backward-compatibility.

But unlike serde, schemars is still in pre-v1, so it's easier to making occasional breaking changes, and this is a case where I'd rather cause an up-front breaking change to avoid a long-term API wart.

While I'm comfortable making this a breaking change, I'm concerned with the ambiguity that would arise from naively updating schemars from 0.8.x (or <v1.0.0-alpha.15) when using `example` - e.g. consider existing code:

```rust
#[derive(JsonSchema)]
pub struct MyStruct {
    #[schemars(example = "foo")]
    pub my_int: i32,
}

fn foo() -> i32 {
   123
}
```

This currently sets the `examples` schema property to `[123]`, but with the new behaviour, would still compile and run, but set the property to `["foo"]`. There would be no clear indication that they would need to change the attribute to either `#[schemars(example = foo())]` or `#[schemars(example = 123)]`.

Because of that, I think the safest way to make this change is to disallow string literals that contain a value parseable as a function path, which will cause a compile error until the attribute is updated. If you do want to set the example value to a such a string, then a simple workaround would be to borrow the string, e.g. `#[schemars(example = &"example")]` which would unambiguously refer to the string value instead of a function `example()`.