### PR TITLE
chore: fix clippy lints

### DIFF
--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -671,13 +671,14 @@ where
 
 impl Debug for Box<dyn GenTransform> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[allow(clippy::used_underscore_items)]
         self._debug_type_name(f)
     }
 }
 
 fn _assert_send() {
-    fn _assert<T: Send>() {}
+    fn assert<T: Send>() {}
 
-    _assert::<SchemaSettings>();
-    _assert::<SchemaGenerator>();
+    assert::<SchemaSettings>();
+    assert::<SchemaGenerator>();
 }

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -145,7 +145,6 @@ pub mod r#gen {
 ///
 /// assert_eq!(<GenericType<i32>>::schema_id(), <&mut GenericType<&i32>>::schema_id());
 /// ```
-
 pub trait JsonSchema {
     /// Whether JSON Schemas generated for this type should be included directly in parent schemas,
     /// rather than being re-used where possible using the `$ref` keyword.

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -48,7 +48,7 @@ impl<'a> Container<'a> {
             .map(|_| result.expect("from_ast set no errors on Ctxt, so should have returned Ok"))
     }
 
-    pub fn transparent_field(&'a self) -> Option<&'a Field> {
+    pub fn transparent_field(&'a self) -> Option<&'a Field<'a>> {
         if self.serde_attrs.transparent() {
             if let Data::Struct(_, fields) = &self.data {
                 return Some(&fields[0]);
@@ -63,7 +63,7 @@ impl<'a> Container<'a> {
     }
 }
 
-impl<'a> Variant<'a> {
+impl Variant<'_> {
     pub fn name(&self) -> Name {
         Name(self.serde_attrs.name())
     }
@@ -85,7 +85,7 @@ impl<'a> Variant<'a> {
     }
 }
 
-impl<'a> Field<'a> {
+impl Field<'_> {
     pub fn name(&self) -> Name {
         Name(self.serde_attrs.name())
     }


### PR DESCRIPTION
I fixed some minor clippy lints. After this PR, `cargo clippy` succeeds without warning.