### PR TITLE
Add `propertyNames` field in maps

### DIFF
--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -133,6 +133,7 @@ impl SchemaSettings {
                 Box::new(SetSingleExample),
                 Box::new(ReplaceConstValue),
                 Box::new(ReplacePrefixItems),
+                Box::new(RemovePropertyNames),
             ],
             inline_subschemas: false,
             contract: Contract::Deserialize,

--- a/schemars/src/json_schema_impls/indexmap2.rs
+++ b/schemars/src/json_schema_impls/indexmap2.rs
@@ -2,5 +2,5 @@ use crate::JsonSchema;
 use alloc::collections::{BTreeMap, BTreeSet};
 use indexmap2::{IndexMap, IndexSet};
 
-forward_impl!((<K, V: JsonSchema, H> JsonSchema for IndexMap<K, V, H>) => BTreeMap<K, V>);
+forward_impl!((<K: JsonSchema, V: JsonSchema, H> JsonSchema for IndexMap<K, V, H>) => BTreeMap<K, V>);
 forward_impl!((<T: JsonSchema, H> JsonSchema for IndexSet<T, H>) => BTreeSet<T>);

--- a/schemars/src/json_schema_impls/maps.rs
+++ b/schemars/src/json_schema_impls/maps.rs
@@ -6,6 +6,7 @@ macro_rules! map_impl {
     ($($desc:tt)+) => {
         impl $($desc)+
         where
+            K: JsonSchema,
             V: JsonSchema,
         {
             always_inline!();
@@ -22,6 +23,7 @@ macro_rules! map_impl {
                 json_schema!({
                     "type": "object",
                     "additionalProperties": generator.subschema_for::<V>(),
+                    "propertyNames": generator.subschema_for::<K>(),
                 })
             }
         }

--- a/schemars/src/transform.rs
+++ b/schemars/src/transform.rs
@@ -448,3 +448,19 @@ impl Transform for GatherPropertyNames {
         transform_immediate_subschemas(self, schema);
     }
 }
+
+/// Removes the `propertyNames` field from JSON Schema objects. This also applies to subschemas.
+///
+/// This is useful for OpenAPI 3.0, which does not support the `propertyNames` field.
+#[derive(Debug, Clone)]
+pub struct RemovePropertyNames;
+
+impl Transform for RemovePropertyNames {
+    fn transform(&mut self, schema: &mut Schema) {
+        transform_subschemas(self, schema);
+
+        if let Some(obj) = schema.as_object_mut() {
+            obj.remove("propertyNames");
+        }
+    }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~adjacently_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~adjacently_tagged_enum.json
@@ -25,6 +25,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "propertyNames": {
+            "type": "string"
           }
         }
       },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~externally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~externally_tagged_enum.json
@@ -16,6 +16,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "propertyNames": {
+            "type": "string"
           }
         }
       },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~internally_tagged_enum.json
@@ -25,6 +25,9 @@
       "additionalProperties": {
         "type": "string"
       },
+      "propertyNames": {
+        "type": "string"
+      },
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum.json
@@ -9,6 +9,9 @@
       "type": "object",
       "additionalProperties": {
         "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
       }
     },
     {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~adjacently_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~adjacently_tagged_enum.json
@@ -26,6 +26,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "propertyNames": {
+            "type": "string"
           }
         }
       },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~externally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~externally_tagged_enum.json
@@ -15,6 +15,9 @@
           "type": "object",
           "additionalProperties": {
             "type": "string"
+          },
+          "propertyNames": {
+            "type": "string"
           }
         }
       },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~internally_tagged_enum.json
@@ -26,6 +26,9 @@
       "additionalProperties": {
         "type": "string"
       },
+      "propertyNames": {
+        "type": "string"
+      },
       "required": [
         "tag"
       ]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~untagged_enum.json
@@ -9,6 +9,9 @@
       "type": "object",
       "additionalProperties": {
         "type": "string"
+      },
+      "propertyNames": {
+        "type": "string"
       }
     },
     {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft07.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft07.de.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft07.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft07.ser.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2019_09.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2019_09.de.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2019_09.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2019_09.ser.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2020_12.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2020_12.de.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2020_12.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~draft2020_12.ser.json
@@ -16,7 +16,10 @@
     },
     "values": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "propertyNames": {
+        "type": "string"
+      }
     },
     "value": true,
     "inner": {


### PR DESCRIPTION
Adds the `propertyNames` field to map schemas and a transformer to remove the field. This is useful in OpenAPI 3.0 which doesn't support it.

This is a breaking change since the key type of maps must now also implement JsonSchema.

Unfortunately, I've not been able to get the `FlattenValue` test working - it's probably because the additional field gets deserialized in only some cases. For this reason, this PR is a draft. I'll try to tinker with it later, but if I could get some advice on resolving this problem, I'd be happy to fix the test.

Fixes #235.