### PR TITLE
Add support for inlining schemas with derive macros (`#[schemars(always_inline)]`)

### DIFF
--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -36,7 +36,7 @@ TABLE OF CONTENTS
    - [`title` / `description`](#title-description)
    - [`example`](#example)
    - [`deprecated`](#deprecated)
-   - [`always_inline`](#always_inline)
+   - [`inline`](#inline)
    - [`crate`](#crate)
    - [`extend`](#extend)
    - [`transform`](#transform)
@@ -317,9 +317,9 @@ Alternatively, to directly set multiple examples without repeating `example = ..
 
 Set the Rust built-in [`deprecated`](https://doc.rust-lang.org/edition-guide/rust-2018/the-compiler/an-attribute-for-deprecation.html) attribute on a struct, enum, field or variant to set the generated schema's `deprecated` keyword to `true`.
 
-<h3 id="always_inline">
+<h3 id="inline">
 
-`#[schemars(always_inline)]`
+`#[schemars(inline)]`
 
 </h3>
 

--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -36,6 +36,7 @@ TABLE OF CONTENTS
    - [`title` / `description`](#title-description)
    - [`example`](#example)
    - [`deprecated`](#deprecated)
+   - [`always_inline`](#always_inline)
    - [`crate`](#crate)
    - [`extend`](#extend)
    - [`transform`](#transform)
@@ -315,6 +316,14 @@ Alternatively, to directly set multiple examples without repeating `example = ..
 </h3>
 
 Set the Rust built-in [`deprecated`](https://doc.rust-lang.org/edition-guide/rust-2018/the-compiler/an-attribute-for-deprecation.html) attribute on a struct, enum, field or variant to set the generated schema's `deprecated` keyword to `true`.
+
+<h3 id="always_inline">
+
+`#[schemars(always_inline)]`
+
+</h3>
+
+Set the return value of [`always_inline_schema`](trait.JsonSchema.html#method.always_inline_schema) to `true` to include JSON schemas generated for this type directly in parent schemas, rather than being re-used where possible using the `$ref` keyword.
 
 <h3 id="crate">
 

--- a/schemars/tests/ui/invalid_attrs.rs
+++ b/schemars/tests/ui/invalid_attrs.rs
@@ -1,11 +1,27 @@
 use schemars::JsonSchema;
 
 #[derive(JsonSchema)]
-#[serde(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
+#[serde(
+    default = 0,
+    foo,
+    deny_unknown_fields,
+    deny_unknown_fields,
+    always_inline = 1,
+    always_inline,
+    always_inline
+)]
 pub struct Struct1;
 
 #[derive(JsonSchema)]
-#[schemars(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
+#[schemars(
+    default = 0,
+    foo,
+    deny_unknown_fields,
+    deny_unknown_fields,
+    always_inline = 1,
+    always_inline,
+    always_inline
+)]
 pub struct Struct2;
 
 fn main() {}

--- a/schemars/tests/ui/invalid_attrs.rs
+++ b/schemars/tests/ui/invalid_attrs.rs
@@ -6,9 +6,9 @@ use schemars::JsonSchema;
     foo,
     deny_unknown_fields,
     deny_unknown_fields,
-    always_inline = 1,
-    always_inline,
-    always_inline
+    inline = 1,
+    inline,
+    inline
 )]
 pub struct Struct1;
 
@@ -18,9 +18,9 @@ pub struct Struct1;
     foo,
     deny_unknown_fields,
     deny_unknown_fields,
-    always_inline = 1,
-    always_inline,
-    always_inline
+    inline = 1,
+    inline,
+    inline
 )]
 pub struct Struct2;
 

--- a/schemars/tests/ui/invalid_attrs.stderr
+++ b/schemars/tests/ui/invalid_attrs.stderr
@@ -1,29 +1,41 @@
 error: expected serde default attribute to be a string: `default = "..."`
- --> $DIR/invalid_attrs.rs:4:19
+ --> tests/ui/invalid_attrs.rs:5:15
   |
-4 | #[serde(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
-  |                   ^
+5 |     default = 0,
+  |               ^
 
 error: duplicate serde attribute `deny_unknown_fields`
- --> $DIR/invalid_attrs.rs:4:48
+ --> tests/ui/invalid_attrs.rs:8:5
   |
-4 | #[serde(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
-  |                                                ^^^^^^^^^^^^^^^^^^^
+8 |     deny_unknown_fields,
+  |     ^^^^^^^^^^^^^^^^^^^
 
 error: expected serde default attribute to be a string: `default = "..."`
- --> $DIR/invalid_attrs.rs:8:22
-  |
-8 | #[schemars(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
-  |                      ^
+  --> tests/ui/invalid_attrs.rs:17:15
+   |
+17 |     default = 0,
+   |               ^
 
 error: duplicate serde attribute `deny_unknown_fields`
- --> $DIR/invalid_attrs.rs:8:51
-  |
-8 | #[schemars(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
-  |                                                   ^^^^^^^^^^^^^^^^^^^
+  --> tests/ui/invalid_attrs.rs:20:5
+   |
+20 |     deny_unknown_fields,
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: unexpected value of schemars always_inline attribute item
+  --> tests/ui/invalid_attrs.rs:21:19
+   |
+21 |     always_inline = 1,
+   |                   ^^^
+
+error: duplicate schemars attribute item `always_inline`
+  --> tests/ui/invalid_attrs.rs:23:5
+   |
+23 |     always_inline
+   |     ^^^^^^^^^^^^^
 
 error: unknown schemars attribute `foo`
- --> $DIR/invalid_attrs.rs:8:25
-  |
-8 | #[schemars(default = 0, foo, deny_unknown_fields, deny_unknown_fields)]
-  |                         ^^^
+  --> tests/ui/invalid_attrs.rs:18:5
+   |
+18 |     foo,
+   |     ^^^

--- a/schemars/tests/ui/invalid_attrs.stderr
+++ b/schemars/tests/ui/invalid_attrs.stderr
@@ -22,17 +22,17 @@ error: duplicate serde attribute `deny_unknown_fields`
 20 |     deny_unknown_fields,
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: unexpected value of schemars always_inline attribute item
-  --> tests/ui/invalid_attrs.rs:21:19
+error: unexpected value of schemars inline attribute item
+  --> tests/ui/invalid_attrs.rs:21:12
    |
-21 |     always_inline = 1,
-   |                   ^^^
+21 |     inline = 1,
+   |            ^^^
 
-error: duplicate schemars attribute item `always_inline`
+error: duplicate schemars attribute item `inline`
   --> tests/ui/invalid_attrs.rs:23:5
    |
-23 |     always_inline
-   |     ^^^^^^^^^^^^^
+23 |     inline
+   |     ^^^^^^
 
 error: unknown schemars attribute `foo`
   --> tests/ui/invalid_attrs.rs:18:5

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -41,7 +41,7 @@ pub struct ContainerAttrs {
     pub repr: Option<Type>,
     pub crate_name: Option<Path>,
     pub is_renamed: bool,
-    pub always_inline: bool,
+    pub inline: bool,
 }
 
 #[derive(Debug, Default)]
@@ -302,11 +302,11 @@ impl ContainerAttrs {
             // The actual parsing of `rename` is done by serde
             "rename" => self.is_renamed = true,
 
-            "always_inline" => {
-                if self.always_inline {
+            "inline" => {
+                if self.inline {
                     cx.duplicate_error(&meta);
                 } else if require_path_only(meta, cx).is_ok() {
-                    self.always_inline = true;
+                    self.inline = true;
                 }
             }
 

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -39,6 +39,7 @@ pub struct ContainerAttrs {
     pub repr: Option<Type>,
     pub crate_name: Option<Path>,
     pub is_renamed: bool,
+    pub always_inline: bool,
 }
 
 #[derive(Debug, Default)]
@@ -298,6 +299,8 @@ impl ContainerAttrs {
 
             // The actual parsing of `rename` is done by serde
             "rename" => self.is_renamed = true,
+
+            "always_inline" => self.always_inline = true,
 
             _ => return Some(meta),
         };

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -3,7 +3,9 @@ mod parse_meta;
 mod schemars_to_serde;
 mod validation;
 
-use parse_meta::{parse_extensions, parse_name_value_expr, parse_name_value_lit_str};
+use parse_meta::{
+    parse_extensions, parse_name_value_expr, parse_name_value_lit_str, require_path_only,
+};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use serde_derive_internals::Ctxt;
@@ -300,7 +302,13 @@ impl ContainerAttrs {
             // The actual parsing of `rename` is done by serde
             "rename" => self.is_renamed = true,
 
-            "always_inline" => self.always_inline = true,
+            "always_inline" => {
+                if self.always_inline {
+                    cx.duplicate_error(&meta);
+                } else if require_path_only(meta, cx).is_ok() {
+                    self.always_inline = true;
+                }
+            }
 
             _ => return Some(meta),
         };

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -178,6 +178,8 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
         schema_exprs::expr_for_container(&cont)
     };
 
+    let always_inline = cont.attrs.always_inline;
+
     Ok(quote! {
         const _: () = {
             #crate_alias
@@ -195,6 +197,10 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
 
                 fn json_schema(#GENERATOR: &mut schemars::SchemaGenerator) -> schemars::Schema {
                     #schema_expr
+                }
+
+                fn always_inline_schema() -> bool {
+                    #always_inline
                 }
             };
         };

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -178,7 +178,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
         schema_exprs::expr_for_container(&cont)
     };
 
-    let always_inline = cont.attrs.always_inline;
+    let inline = cont.attrs.inline;
 
     Ok(quote! {
         const _: () = {
@@ -200,7 +200,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                 }
 
                 fn always_inline_schema() -> bool {
-                    #always_inline
+                    #inline
                 }
             };
         };


### PR DESCRIPTION
Closes #211.

This PR allows configuring `JsonSchema::always_inline_schema` through the derive API, without needing to manually implement the trait.

Also adds a brief description of this attribute to the docs.

```rust
#[derive(JsonSchema)]
struct Foo { ... }

#[derive(JsonSchema)]
#[schemars(always_inline)]
struct Bar { ... }

assert_eq!(Foo::always_inline_schema(), false);
assert_eq!(Bar::always_inline_schema(), true);
```