### PR TITLE
Drive "nullable" behaviour from a new transform

### DIFF
--- a/docs/_includes/examples/custom_settings.rs
+++ b/docs/_includes/examples/custom_settings.rs
@@ -15,8 +15,8 @@ pub enum MyEnum {
 
 fn main() {
     let settings = SchemaSettings::draft07().with(|s| {
-        s.option_nullable = true;
-        s.option_add_null_type = false;
+        s.meta_schema = None;
+        s.inline_subschemas = true;
     });
     let generator = settings.into_generator();
     let schema = generator.into_root_schema_for::<MyStruct>();

--- a/docs/_includes/examples/custom_settings.schema.json
+++ b/docs/_includes/examples/custom_settings.schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MyStruct",
   "type": "object",
   "properties": {
@@ -11,58 +10,55 @@
       "format": "int32"
     },
     "my_nullable_enum": {
-      "allOf": [
+      "anyOf": [
         {
-          "$ref": "#/definitions/MyEnum"
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "StringNewType": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "StringNewType"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "StructVariant": {
+                  "type": "object",
+                  "properties": {
+                    "floats": {
+                      "type": "array",
+                      "items": {
+                        "type": "number",
+                        "format": "float"
+                      }
+                    }
+                  },
+                  "required": [
+                    "floats"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "StructVariant"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "null"
         }
-      ],
-      "nullable": true
+      ]
     }
   },
   "required": [
     "my_int",
     "my_bool"
-  ],
-  "definitions": {
-    "MyEnum": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "StringNewType": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "StringNewType"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "StructVariant": {
-              "type": "object",
-              "properties": {
-                "floats": {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  }
-                }
-              },
-              "required": [
-                "floats"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "StructVariant"
-          ]
-        }
-      ]
-    }
-  }
+  ]
 }

--- a/schemars/examples/custom_settings.rs
+++ b/schemars/examples/custom_settings.rs
@@ -15,8 +15,8 @@ pub enum MyEnum {
 
 fn main() {
     let settings = SchemaSettings::draft07().with(|s| {
-        s.option_nullable = true;
-        s.option_add_null_type = false;
+        s.meta_schema = None;
+        s.inline_subschemas = true;
     });
     let generator = settings.into_generator();
     let schema = generator.into_root_schema_for::<MyStruct>();

--- a/schemars/examples/custom_settings.schema.json
+++ b/schemars/examples/custom_settings.schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MyStruct",
   "type": "object",
   "properties": {
@@ -11,58 +10,55 @@
       "format": "int32"
     },
     "my_nullable_enum": {
-      "allOf": [
+      "anyOf": [
         {
-          "$ref": "#/definitions/MyEnum"
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "StringNewType": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "StringNewType"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "StructVariant": {
+                  "type": "object",
+                  "properties": {
+                    "floats": {
+                      "type": "array",
+                      "items": {
+                        "type": "number",
+                        "format": "float"
+                      }
+                    }
+                  },
+                  "required": [
+                    "floats"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "StructVariant"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "null"
         }
-      ],
-      "nullable": true
+      ]
     }
   },
   "required": [
     "my_int",
     "my_bool"
-  ],
-  "definitions": {
-    "MyEnum": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "StringNewType": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "StringNewType"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "StructVariant": {
-              "type": "object",
-              "properties": {
-                "floats": {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  }
-                }
-              },
-              "required": [
-                "floats"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "StructVariant"
-          ]
-        }
-      ]
-    }
-  }
+  ]
 }

--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -329,7 +329,7 @@ fn normalise_additional_unevaluated_properties(
 }
 
 fn contains_immediate_subschema(schema_obj: &Map<String, Value>) -> bool {
-    ["if", "then", "else", "allOf", "anyOf", "oneOf", "$ref"]
+    ["if", "allOf", "anyOf", "oneOf", "$ref"]
         .into_iter()
         .any(|k| schema_obj.contains_key(k))
 }

--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -328,7 +328,7 @@ fn normalise_additional_unevaluated_properties(
     }
 }
 
-fn contains_immediate_subschema(schema_obj: &Map<String, Value>) -> bool {
+pub(crate) fn contains_immediate_subschema(schema_obj: &Map<String, Value>) -> bool {
     ["if", "then", "else", "allOf", "anyOf", "oneOf", "$ref"]
         .into_iter()
         .any(|k| schema_obj.contains_key(k))

--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -26,15 +26,11 @@ type CowStr = alloc::borrow::Cow<'static, str>;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct SchemaSettings {
-    /// If `true`, schemas for [`Option<T>`] will include a `nullable` property.
-    ///
-    /// This is not part of the JSON Schema spec, but is used in Swagger/OpenAPI schemas.
-    ///
-    /// Defaults to `false`.
+    /// This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead.
+    #[deprecated = "This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead."]
     pub option_nullable: bool,
-    /// If `true`, schemas for [`Option<T>`] will have `null` added to their `type` property.
-    ///
-    /// Defaults to `true`.
+    /// This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead.
+    #[deprecated = "This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead."]
     pub option_add_null_type: bool,
     /// A JSON pointer to the expected location of referenceable subschemas within the resulting
     /// root schema.
@@ -73,6 +69,7 @@ impl Default for SchemaSettings {
 impl SchemaSettings {
     /// Creates `SchemaSettings` that conform to [JSON Schema Draft 7](https://json-schema.org/specification-links#draft-7).
     pub fn draft07() -> SchemaSettings {
+        #[allow(deprecated)]
         SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
@@ -90,6 +87,7 @@ impl SchemaSettings {
 
     /// Creates `SchemaSettings` that conform to [JSON Schema 2019-09](https://json-schema.org/specification-links#draft-2019-09-(formerly-known-as-draft-8)).
     pub fn draft2019_09() -> SchemaSettings {
+        #[allow(deprecated)]
         SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
@@ -103,6 +101,7 @@ impl SchemaSettings {
 
     /// Creates `SchemaSettings` that conform to [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12).
     pub fn draft2020_12() -> SchemaSettings {
+        #[allow(deprecated)]
         SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
@@ -116,6 +115,7 @@ impl SchemaSettings {
 
     /// Creates `SchemaSettings` that conform to [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schema).
     pub fn openapi3() -> SchemaSettings {
+        #[allow(deprecated)]
         SchemaSettings {
             option_nullable: true,
             option_add_null_type: false,
@@ -126,10 +126,11 @@ impl SchemaSettings {
             ),
             transforms: vec![
                 Box::new(ReplaceUnevaluatedProperties),
-                Box::new(RemoveRefSiblings),
                 Box::new(ReplaceBoolSchemas {
                     skip_additional_properties: true,
                 }),
+                Box::new(AddNullable::default()),
+                Box::new(RemoveRefSiblings),
                 Box::new(SetSingleExample),
                 Box::new(ReplaceConstValue),
                 Box::new(ReplacePrefixItems),
@@ -146,8 +147,8 @@ impl SchemaSettings {
     /// use schemars::generate::{SchemaGenerator, SchemaSettings};
     ///
     /// let settings = SchemaSettings::default().with(|s| {
-    ///     s.option_nullable = true;
-    ///     s.option_add_null_type = false;
+    ///     s.meta_schema = None;
+    ///     s.inline_subschemas = true;
     /// });
     /// let generator = settings.into_generator();
     /// ```
@@ -223,13 +224,19 @@ struct SchemaUid(CowStr, Contract);
 /// let generator = SchemaGenerator::default();
 /// let schema = generator.into_root_schema_for::<MyStruct>();
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SchemaGenerator {
     settings: SchemaSettings,
     definitions: JsonMap<String, Value>,
     pending_schema_ids: BTreeSet<SchemaUid>,
     schema_id_to_name: BTreeMap<SchemaUid, CowStr>,
     used_schema_names: BTreeSet<CowStr>,
+}
+
+impl Default for SchemaGenerator {
+    fn default() -> Self {
+        SchemaSettings::default().into_generator()
+    }
 }
 
 impl Clone for SchemaGenerator {
@@ -255,7 +262,10 @@ impl SchemaGenerator {
     pub fn new(settings: SchemaSettings) -> SchemaGenerator {
         SchemaGenerator {
             settings,
-            ..Default::default()
+            definitions: JsonMap::new(),
+            pending_schema_ids: BTreeSet::new(),
+            schema_id_to_name: BTreeMap::new(),
+            used_schema_names: BTreeSet::new(),
         }
     }
 

--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -26,11 +26,15 @@ type CowStr = alloc::borrow::Cow<'static, str>;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct SchemaSettings {
-    /// This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead.
-    #[deprecated = "This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead."]
+    /// This option is now ignored and will be removed before schemars 1.0 becomes stable.
+    ///
+    /// If you need the `nullable` keyword to be added to schemas for [`Option<T>`], you should use the [`AddNullable`] transform.
+    #[deprecated = "This option is now ignored. If you need the `nullable` keyword to be added to schemas for `Option<T>`, you should use the `AddNullable` transform."]
     pub option_nullable: bool,
-    /// This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead.
-    #[deprecated = "This option is now ignored - if you need the `nullable` keyword to be added to schemas, you should use the [`AddNullable`] transform instead."]
+    /// This option is now ignored and will be removed before schemars 1.0 becomes stable.
+    ///
+    /// The null type is now always added to schema for [`Option<T>`], but may be removed if using the [`AddNullable`] transform.
+    #[deprecated = "This option is now ignored."]
     pub option_add_null_type: bool,
     /// A JSON pointer to the expected location of referenceable subschemas within the resulting
     /// root schema.
@@ -58,9 +62,9 @@ pub struct SchemaSettings {
 }
 
 impl Default for SchemaSettings {
-    /// The default settings currently conform to [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12), but this is liable to change in a future version of Schemars if support for other JSON Schema versions is added.
-    /// If you rely on generated schemas conforming to draft 2020-12, consider using the
-    /// [`SchemaSettings::draft2020_12()`] method.
+    /// The default settings currently conform to [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12),
+    /// but this is liable to change in a future version of Schemars if support for other JSON Schema versions is added.
+    /// If you rely on generated schemas conforming to draft 2020-12, consider using [`SchemaSettings::draft2020_12()`] instead.
     fn default() -> SchemaSettings {
         SchemaSettings::draft2020_12()
     }

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -3,7 +3,9 @@
     missing_docs,
     unused_imports,
     clippy::cargo,
-    clippy::pedantic
+    clippy::pedantic,
+    clippy::exhaustive_structs,
+    clippy::exhaustive_enums
 )]
 #![allow(
     clippy::must_use_candidate,
@@ -29,6 +31,7 @@ mod macros;
 /// This module is only public for use by `schemars_derive`. It should not need to be used by code
 /// outside of `schemars`, and should not be considered part of the public API.
 #[doc(hidden)]
+#[allow(clippy::exhaustive_structs)]
 pub mod _private;
 pub mod generate;
 pub mod transform;

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -85,6 +85,42 @@ impl Serialize for Schema {
     }
 }
 
+impl PartialEq<bool> for Schema {
+    fn eq(&self, other: &bool) -> bool {
+        self.as_bool() == Some(*other)
+    }
+}
+
+impl PartialEq<Map<String, Value>> for Schema {
+    fn eq(&self, other: &Map<String, Value>) -> bool {
+        self.as_object() == Some(other)
+    }
+}
+
+impl PartialEq<Value> for Schema {
+    fn eq(&self, other: &Value) -> bool {
+        self.as_value() == other
+    }
+}
+
+impl PartialEq<Schema> for bool {
+    fn eq(&self, other: &Schema) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<Schema> for Map<String, Value> {
+    fn eq(&self, other: &Schema) -> bool {
+        other == self
+    }
+}
+
+impl PartialEq<Schema> for Value {
+    fn eq(&self, other: &Schema) -> bool {
+        other == self
+    }
+}
+
 impl Schema {
     /// Creates a new schema object with a single string property `"$ref"`.
     ///
@@ -178,7 +214,7 @@ impl Schema {
     }
 
     /// If the `Schema`'s underlying JSON value is an object, gets a reference to that object's
-    /// value for the given key.
+    /// value for the given key if it exists.
     ///
     /// This always returns `None` for bool schemas.
     ///

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -162,6 +162,14 @@ impl Schema {
         }
     }
 
+    pub(crate) fn try_as_object_mut(&mut self) -> Result<&mut Map<String, Value>, bool> {
+        match &mut self.0 {
+            Value::Object(m) => Ok(m),
+            Value::Bool(b) => Err(*b),
+            _ => unreachable!(),
+        }
+    }
+
     /// Returns the `Schema`'s underlying JSON value.
     pub fn to_value(self) -> Value {
         self.0

--- a/schemars/src/transform.rs
+++ b/schemars/src/transform.rs
@@ -257,6 +257,7 @@ pub(crate) fn transform_immediate_subschemas<T: Transform + ?Sized>(
 /// );
 /// ```
 #[derive(Debug, Clone)]
+#[allow(clippy::exhaustive_structs)]
 pub struct RecursiveTransform<T>(pub T);
 
 impl<T> Transform for RecursiveTransform<T>

--- a/schemars/src/transform.rs
+++ b/schemars/src/transform.rs
@@ -280,6 +280,8 @@ where
 pub struct ReplaceBoolSchemas {
     /// When set to `true`, a schema's `additionalProperties` property will not be changed from a
     /// boolean.
+    ///
+    /// Defaults to `false`.
     pub skip_additional_properties: bool,
 }
 
@@ -403,10 +405,10 @@ impl Transform for ReplacePrefixItems {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct AddNullable {
-    /// When set to `true`, `"null"` will also be removed from the schemas `type`.
+    /// When set to `true` (the default), `"null"` will also be removed from the schemas `type`.
     pub remove_null_type: bool,
-    /// When set to `true`, a schema that has a type only allowing `null` will also have the
-    /// equivalent `"const": null` inserted.
+    /// When set to `true` (the default), a schema that has a type only allowing `null` will also
+    /// have the equivalent `"const": null` inserted.
     pub add_const_null: bool,
 }
 

--- a/schemars/src/transform.rs
+++ b/schemars/src/transform.rs
@@ -422,9 +422,8 @@ impl Default for AddNullable {
 impl Transform for AddNullable {
     fn transform(&mut self, schema: &mut Schema) {
         if schema.has_type("null") {
-            let Some(obj) = schema.as_object_mut() else {
-                unreachable!();
-            };
+            // has_type returned true so we know schema is an object
+            let obj = schema.as_object_mut().unwrap();
 
             obj.insert("nullable".into(), true.into());
 

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~custom_struct_openapi3.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~custom_struct_openapi3.json
@@ -9,9 +9,7 @@
     "myBool": {
       "type": "boolean"
     },
-    "myNullableEnum": {
-      "nullable": true
-    },
+    "myNullableEnum": {},
     "myInnerStruct": {
       "type": "object",
       "properties": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~openapi3.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~openapi3.de.json
@@ -18,10 +18,15 @@
       "$ref": "#/components/schemas/InnerEnum"
     },
     "maybe_inner": {
-      "nullable": true,
-      "allOf": [
+      "anyOf": [
         {
           "$ref": "#/components/schemas/InnerEnum"
+        },
+        {
+          "nullable": true,
+          "enum": [
+            null
+          ]
         }
       ]
     },

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~openapi3.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/settings.rs~openapi3.ser.json
@@ -18,10 +18,15 @@
       "$ref": "#/components/schemas/InnerEnum"
     },
     "maybe_inner": {
-      "nullable": true,
-      "allOf": [
+      "anyOf": [
         {
           "$ref": "#/components/schemas/InnerEnum"
+        },
+        {
+          "nullable": true,
+          "enum": [
+            null
+          ]
         }
       ]
     },


### PR DESCRIPTION
The `option_nullable` and `option_add_null_type` settings were always a bit weird because they didn't change the behaviour of `SchemaGenerator`, they were only checked by the `JsonSchema` impl for `Option<T>`. This meant that if someone wanted to implement `JsonSchema` on a custom type that may map to a `null` JSON value, they would need to know to check those fields for the implementation to be correct when used for openapi 3.0 schemas.

This PR removes (or for now, deprecates and stops using) `option_nullable` and `option_add_null_type`. Now, `Option<T>` always adds a null type, since that's the standard for JSON Schema. To continue supporting openapi 3.0, this PR also adds a new transform `AddNullable`. This, as the name suggests, adds the `nullable` property to schemas that allow the null type, and (optionally) remove the null type.

The new helper for generating nullable schemas will now also correctly update schemas with `const` or `enum` properties, which fixes #382.

Misc changes in this PR not directly related to the main change:
- Make all transforms `#[non_exhaustive]` to allow more settings to be added to them later if necessary
- Implement `PartialEq` between `Schema` and `bool`/`Value`/`Map<String, Value>` and vice-versa