### PR TITLE
Deprecate `as_any`/`as_any_mut`, add downcast methods to `dyn GenTransform`

### DIFF
--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -644,26 +644,56 @@ pub trait GenTransform: Transform + DynClone + Any + Send {
 
 #[allow(deprecated)]
 impl dyn GenTransform {
-    /// TODO doc
+    /// Returns `true` if the inner transform is of type `T`.
     pub fn is<T: Transform + Clone + Any + Send>(&self) -> bool {
         self.as_any().is::<T>()
     }
 
-    /// TODO doc
+    /// Returns some reference to the inner transform if it is of type `T`, or
+    /// `None` if it isn't.
+    ///
+    /// # Example
+    /// To remove a specific transform from an instance of `SchemaSettings`:
+    /// ```
+    /// use schemars::generate::SchemaSettings;
+    /// use schemars::transform::ReplaceBoolSchemas;
+    ///
+    /// let mut settings = SchemaSettings::openapi3();
+    /// let original_len = settings.transforms.len();
+    ///
+    /// settings.transforms.retain(|t| !t.is::<ReplaceBoolSchemas>());
+    ///
+    /// assert_eq!(settings.transforms.len(), original_len - 1);
+    /// ```
     pub fn downcast_ref<T: Transform + Clone + Any + Send>(&self) -> Option<&T> {
         self.as_any().downcast_ref::<T>()
     }
 
-    /// TODO doc
+    /// Returns some mutable reference to the inner transform if it is of type `T`, or
+    /// `None` if it isn't.
+    ///
+    /// # Example
+    /// To modify a specific transform in an instance of `SchemaSettings`:
+    /// ```
+    /// use schemars::generate::SchemaSettings;
+    /// use schemars::transform::ReplaceBoolSchemas;
+    ///
+    /// let mut settings = SchemaSettings::openapi3();
+    /// for t in &mut settings.transforms {
+    ///     if let Some(replace_bool_schemas) = t.downcast_mut::<ReplaceBoolSchemas>() {
+    ///         replace_bool_schemas.skip_additional_properties = false;
+    ///     }
+    /// }
+    /// ```
     pub fn downcast_mut<T: Transform + Clone + Any + Send>(&mut self) -> Option<&mut T> {
         self.as_any_mut().downcast_mut::<T>()
     }
 
-    /// TODO doc
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "`is()` ensures that downcast succeeds"
-    )]
+    /// Attempts to downcast the box to a concrete type.
+    ///
+    /// If the inner transform is not of type `T`, this returns `self` wrapped in an `Err` so that
+    /// it can still be used.
+    #[allow(clippy::missing_panics_doc)] // should never panic - `is()` ensures that downcast succeeds
     pub fn downcast<T: Transform + Clone + Any + Send>(
         self: Box<Self>,
     ) -> Result<Box<T>, Box<Self>> {


### PR DESCRIPTION
Once MSRV is raised to 1.86+, we can use trait upcasting and so the deprecated methods can be removed entirely.