### PR TITLE
Add `RestrictFormats` transform

### DIFF
--- a/schemars/src/consts.rs
+++ b/schemars/src/consts.rs
@@ -1,0 +1,26 @@
+/*!
+Constants associated with JSON Schema generation.
+*/
+
+/// Known values of the `$schema` property.
+pub mod meta_schemas {
+    /// The mata-schema for [JSON Schema Draft 7](https://json-schema.org/specification-links#draft-7)
+    /// (`http://json-schema.org/draft-07/schema#`).
+    pub const DRAFT07: &str = "http://json-schema.org/draft-07/schema#";
+
+    /// The mata-schema for [JSON Schema 2019-09](https://json-schema.org/specification-links#draft-2019-09-(formerly-known-as-draft-8))
+    /// (`https://json-schema.org/draft/2019-09/schema`).
+    pub const DRAFT2019_09: &str = "https://json-schema.org/draft/2019-09/schema";
+
+    /// The mata-schema for [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12)
+    /// (`https://json-schema.org/draft/2020-12/schema`).
+    pub const DRAFT2020_12: &str = "https://json-schema.org/draft/2020-12/schema";
+
+    /// The mata-schema for [OpenAPI 3.0 schemas](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#schema)
+    /// (`https://spec.openapis.org/oas/3.0/schema/2024-10-18#/definitions/Schema`).
+    ///
+    /// This should rarely be encountered in practice, as OpenAPI schemas are typically only
+    /// embedded within OpenAPI documents, so do not have a `$schema` property set.
+    pub const OPENAPI3: &str =
+        "https://spec.openapis.org/oas/3.0/schema/2024-10-18#/definitions/Schema";
+}

--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -7,6 +7,7 @@ There are two main types in this module:
 * [`SchemaGenerator`], which manages the generation of a schema document.
 */
 
+use crate::consts::meta_schemas;
 use crate::Schema;
 use crate::_alloc_prelude::*;
 use crate::{transform::*, JsonSchema};
@@ -45,7 +46,7 @@ pub struct SchemaSettings {
     pub definitions_path: CowStr,
     /// The URI of the meta-schema describing the structure of the generated schemas.
     ///
-    /// Defaults to `"https://json-schema.org/draft/2020-12/schema"`.
+    /// Defaults to [`meta_schemas::DRAFT2020_12`] (`https://json-schema.org/draft/2020-12/schema`).
     pub meta_schema: Option<CowStr>,
     /// A list of [`Transform`]s that get applied to generated root schemas.
     pub transforms: Vec<Box<dyn GenTransform>>,
@@ -78,7 +79,7 @@ impl SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
             definitions_path: "/definitions".into(),
-            meta_schema: Some("http://json-schema.org/draft-07/schema#".into()),
+            meta_schema: Some(meta_schemas::DRAFT07.into()),
             transforms: vec![
                 Box::new(ReplaceUnevaluatedProperties),
                 Box::new(RemoveRefSiblings),
@@ -96,7 +97,7 @@ impl SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
             definitions_path: "/$defs".into(),
-            meta_schema: Some("https://json-schema.org/draft/2019-09/schema".into()),
+            meta_schema: Some(meta_schemas::DRAFT2019_09.into()),
             transforms: vec![Box::new(ReplacePrefixItems)],
             inline_subschemas: false,
             contract: Contract::Deserialize,
@@ -110,7 +111,7 @@ impl SchemaSettings {
             option_nullable: false,
             option_add_null_type: true,
             definitions_path: "/$defs".into(),
-            meta_schema: Some("https://json-schema.org/draft/2020-12/schema".into()),
+            meta_schema: Some(meta_schemas::DRAFT2020_12.into()),
             transforms: Vec::new(),
             inline_subschemas: false,
             contract: Contract::Deserialize,
@@ -124,9 +125,7 @@ impl SchemaSettings {
             option_nullable: true,
             option_add_null_type: false,
             definitions_path: "/components/schemas".into(),
-            meta_schema: Some(
-                "https://spec.openapis.org/oas/3.0/schema/2024-10-18#/definitions/Schema".into(),
-            ),
+            meta_schema: Some(meta_schemas::OPENAPI3.into()),
             transforms: vec![
                 Box::new(ReplaceUnevaluatedProperties),
                 Box::new(ReplaceBoolSchemas {

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -33,6 +33,7 @@ mod macros;
 #[doc(hidden)]
 #[allow(clippy::exhaustive_structs)]
 pub mod _private;
+pub mod consts;
 pub mod generate;
 pub mod transform;
 


### PR DESCRIPTION
Fixes #345, #208, #97 - although the "fix" is opt-in, i.e. consumers must explicitly create and use a `RestrictFormats`.

Example usage:
```rust
let mut schema = schema_for!(MyStruct);
// `schema` may currently contain non-standard formats...

RestrictFormats::default().transform(&mut schema);
// `schema` no longer contains non-standard formats!
```

Or alternatively, adding the transform to the `SchemaSettings`:
```rust
let schema = SchemaSettings::default()
    .with_transform(RestrictFormats::default())
    .into_generator()
    .into_root_schema_for::<MyStruct>();
```