### PR TITLE
Fail compilation when encountering `with` container attribute

### DIFF
--- a/schemars/tests/ui/invalid_attrs.rs
+++ b/schemars/tests/ui/invalid_attrs.rs
@@ -8,9 +8,14 @@ use schemars::JsonSchema;
     deny_unknown_fields,
     inline = 1,
     inline,
-    inline
+    inline,
+    with = "String",
+    serialize_with = "String"
 )]
-pub struct Struct1;
+pub struct Struct1 {
+    #[serde(serialize_with = "u64")]
+    pub field: u32,
+}
 
 #[derive(JsonSchema)]
 #[schemars(
@@ -20,8 +25,13 @@ pub struct Struct1;
     deny_unknown_fields,
     inline = 1,
     inline,
-    inline
+    inline,
+    with = "String",
+    serialize_with = "String"
 )]
-pub struct Struct2;
+pub struct Struct2 {
+    #[schemars(serialize_with = "u64")]
+    pub field: u32,
+}
 
 fn main() {}

--- a/schemars/tests/ui/invalid_attrs.stderr
+++ b/schemars/tests/ui/invalid_attrs.stderr
@@ -10,32 +10,56 @@ error: duplicate serde attribute `deny_unknown_fields`
 8 |     deny_unknown_fields,
   |     ^^^^^^^^^^^^^^^^^^^
 
-error: expected serde default attribute to be a string: `default = "..."`
-  --> tests/ui/invalid_attrs.rs:17:15
+error: unknown serde container attribute `with`
+  --> tests/ui/invalid_attrs.rs:12:5
    |
-17 |     default = 0,
+12 |     with = "String",
+   |     ^^^^
+
+error: expected serde default attribute to be a string: `default = "..."`
+  --> tests/ui/invalid_attrs.rs:22:15
+   |
+22 |     default = 0,
    |               ^
 
 error: duplicate serde attribute `deny_unknown_fields`
-  --> tests/ui/invalid_attrs.rs:20:5
+  --> tests/ui/invalid_attrs.rs:25:5
    |
-20 |     deny_unknown_fields,
+25 |     deny_unknown_fields,
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: unexpected value of schemars inline attribute item
-  --> tests/ui/invalid_attrs.rs:21:12
+error: unknown schemars attribute `serialize_with`
+  --> tests/ui/invalid_attrs.rs:33:16
    |
-21 |     inline = 1,
+33 |     #[schemars(serialize_with = "u64")]
+   |                ^^^^^^^^^^^^^^
+
+error: unexpected value of schemars inline attribute item
+  --> tests/ui/invalid_attrs.rs:26:12
+   |
+26 |     inline = 1,
    |            ^^^
 
 error: duplicate schemars attribute item `inline`
-  --> tests/ui/invalid_attrs.rs:23:5
+  --> tests/ui/invalid_attrs.rs:28:5
    |
-23 |     inline
+28 |     inline,
    |     ^^^^^^
 
 error: unknown schemars attribute `foo`
-  --> tests/ui/invalid_attrs.rs:18:5
+  --> tests/ui/invalid_attrs.rs:23:5
    |
-18 |     foo,
+23 |     foo,
    |     ^^^
+
+error: unknown schemars attribute `with`
+  --> tests/ui/invalid_attrs.rs:29:5
+   |
+29 |     with = "String",
+   |     ^^^^
+
+error: unknown schemars attribute `serialize_with`
+  --> tests/ui/invalid_attrs.rs:30:5
+   |
+30 |     serialize_with = "String"
+   |     ^^^^^^^^^^^^^^

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -463,7 +463,7 @@ impl<'a> AttrCtxt<'a> {
 impl Drop for AttrCtxt<'_> {
     fn drop(&mut self) {
         if self.attr_type == "schemars" {
-            for unhandled_meta in self.metas.iter().filter(|m| !is_known_serde_keyword(m)) {
+            for unhandled_meta in self.metas.iter().filter(|m| !is_schemars_serde_keyword(m)) {
                 self.error_spanned_by(
                     unhandled_meta.path(),
                     format_args!(
@@ -476,8 +476,8 @@ impl Drop for AttrCtxt<'_> {
     }
 }
 
-fn is_known_serde_keyword(meta: &Meta) -> bool {
-    let known_keywords = schemars_to_serde::SERDE_KEYWORDS;
+fn is_schemars_serde_keyword(meta: &Meta) -> bool {
+    let known_keywords = schemars_to_serde::SCHEMARS_KEYWORDS_PARSED_BY_SERDE;
     meta.path()
         .get_ident()
         .map(|i| known_keywords.contains(&i.to_string().as_str()))

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -37,6 +37,10 @@ pub(crate) static SERDE_KEYWORDS: &[&str] = &[
     "with",
 ];
 
+pub(crate) static SCHEMARS_KEYWORDS_PARSED_BY_SERDE: &[&str] =
+    // exclude "serialize_with" and "with"
+    SERDE_KEYWORDS.split_at(SERDE_KEYWORDS.len() - 2).0;
+
 // If a struct/variant/field has any #[schemars] attributes, then create copies of them
 // as #[serde] attributes so that serde_derive_internals will parse them for us.
 pub fn process_serde_attrs(input: &mut syn::DeriveInput) -> syn::Result<()> {
@@ -76,7 +80,7 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
             .into_iter()
             .filter_map(|meta| {
                 let keyword = get_meta_ident(&meta)?;
-                if SERDE_KEYWORDS.contains(&keyword.as_ref()) && !keyword.ends_with("with") {
+                if SCHEMARS_KEYWORDS_PARSED_BY_SERDE.contains(&keyword.as_ref()) {
                     Some((meta, keyword))
                 } else {
                     None


### PR DESCRIPTION
The `#[schemars(with = "...")]` attribute is not allowed on containers, but did not fail compilation, it was just silently ignored. This may mislead users into thinking that it was being processed.

Similarly, the `#[schemars(serialize_with = "...")]` attribute is never allowed, but also did not fail compilation.