### PR TITLE
When a struct is `transparent`, don't ignore other attributes

### DIFF
--- a/schemars/tests/integration/snapshots/schemars/tests/integration/transparent.rs~transparent_newtype_with_validation.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/transparent.rs~transparent_newtype_with_validation.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TransparentNewTypeWithValidation",
+  "type": "string",
+  "minLength": 1
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/transparent.rs~transparent_struct_with_doc.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/transparent.rs~transparent_struct_with_doc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TransparentStructWithDoc",
+  "description": "A doc comment",
+  "type": "string"
+}

--- a/schemars/tests/integration/transparent.rs
+++ b/schemars/tests/integration/transparent.rs
@@ -16,6 +16,21 @@ fn transparent_struct() {
 
 #[derive(JsonSchema, Deserialize, Serialize, Default)]
 #[serde(transparent)]
+/// A doc comment
+pub struct TransparentStructWithDoc {
+    inner: String,
+}
+
+#[test]
+fn transparent_struct_with_doc() {
+    test!(TransparentStructWithDoc)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Default)]
+#[serde(transparent)]
 pub struct TransparentNewType(String);
 
 #[test]
@@ -23,5 +38,18 @@ fn transparent_newtype() {
     test!(TransparentNewType)
         .assert_identical::<String>()
         .assert_allows_ser_roundtrip_default()
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct TransparentNewTypeWithValidation(#[schemars(length(min = 1))] String);
+
+#[test]
+fn transparent_newtype_with_validation() {
+    test!(TransparentNewTypeWithValidation)
+        .with_validator(|v| !v.0.is_empty())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([TransparentNewTypeWithValidation("a@a.com".into())])
         .assert_matches_de_roundtrip(arbitrary_values());
 }

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -150,7 +150,7 @@ impl CommonAttrs {
         None
     }
 
-    fn is_default(&self) -> bool {
+    pub fn is_default(&self) -> bool {
         matches!(
             self,
             Self {
@@ -263,6 +263,16 @@ impl FieldAttrs {
         }
 
         None
+    }
+
+    pub fn is_default(&self) -> bool {
+        matches!(
+            self,
+            Self {
+                common,
+                validation,
+                with: None,
+            } if common.is_default() && validation.is_default())
     }
 }
 

--- a/schemars_derive/src/attr/validation.rs
+++ b/schemars_derive/src/attr/validation.rs
@@ -230,4 +230,20 @@ impl ValidationAttrs {
             }
         }
     }
+
+    pub(crate) fn is_default(&self) -> bool {
+        matches!(
+            self,
+            Self {
+                contains: None,
+                format: None,
+                length: None,
+                range: None,
+                pattern: None,
+                regex: None,
+                required: false,
+                inner: None,
+            }
+        )
+    }
 }

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -53,6 +53,9 @@ pub fn expr_for_container(cont: &Container) -> SchemaExpr {
         Data::Struct(Style::Unit, _) => expr_for_unit_struct(),
         Data::Struct(Style::Newtype, fields) => expr_for_newtype_struct(&fields[0]),
         Data::Struct(Style::Tuple, fields) => expr_for_tuple_struct(fields),
+        Data::Struct(Style::Struct, fields) if cont.serde_attrs.transparent() => {
+            expr_for_newtype_struct(&fields[0])
+        }
         Data::Struct(Style::Struct, fields) => expr_for_struct(
             fields,
             cont.serde_attrs.default(),


### PR DESCRIPTION
Fixes #107

With this PR, when a struct has `#[serde(transparent)]` and any* other attributes that affect schema generation (including doc comments), the resulting schema won't be identical to the inner type, but we will still handle the transparent serialization/deserialization contract appropriately (specifically, by treating the struct as though it were newtype).

This means that putting ` #[serde(transparent)]`/ `#[schemars(transparent)]` on a newtype that has any* other attributes is essentially a no-op, which is fine.

*excluding a few attributes ( e.g. `schema_with`) which were already respected when present on a transparent struct