### PR TITLE
Better handle non-`JsonSchema` type params

### DIFF
--- a/schemars/tests/integration/bound.rs
+++ b/schemars/tests/integration/bound.rs
@@ -11,10 +11,11 @@ impl Iterator for MyIterator {
     }
 }
 
-// The default trait bounds would require T to implement JsonSchema,
-// which MyIterator does not.
+// The default trait bounds would require T to implement JsonSchema, which MyIterator does not.
+// Ideally we wouldn't need the `bound` attribute here at all - it should be possible to better
+// infer automatic trait bounds (tracked in https://github.com/GREsau/schemars/issues/168)
 #[derive(JsonSchema, Serialize, Deserialize)]
-#[schemars(bound = "T::Item: JsonSchema", rename = "MyContainer")]
+#[schemars(bound = "T::Item: JsonSchema")]
 pub struct MyContainer<T>
 where
     T: Iterator,

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~manual_bound_set.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~manual_bound_set.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "MyContainer",
+  "title": "MyContainer_for_T",
   "type": "object",
   "properties": {
     "associated": {

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -133,7 +133,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                 schemars::_private::alloc::borrow::Cow::Owned(
                     schemars::_private::alloc::format!(
                         #schema_name_fmt
-                        #(,#type_params=#type_params::schema_name())*
+                        #(,#type_params=schemars::_schemars_maybe_schema_name!(#type_params))*
                         #(,#const_params=schemars::_private::alloc::string::ToString::to_string(&#const_params))*)
                 )
             },
@@ -145,7 +145,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                             "::",
                             #schema_name_fmt
                         )
-                        #(,#type_params=#type_params::schema_id())*
+                        #(,#type_params=schemars::_schemars_maybe_schema_id!(#type_params))*
                         #(,#const_params=#const_params)*
                     )
                 )
@@ -158,7 +158,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
         (
             quote! {
                 schemars::_private::alloc::borrow::Cow::Owned(
-                    schemars::_private::alloc::format!(#schema_name_fmt #(,#type_params::schema_name())* #(,#const_params)*)
+                    schemars::_private::alloc::format!(#schema_name_fmt #(,schemars::_schemars_maybe_schema_name!(#type_params))* #(,#const_params)*)
                 )
             },
             quote! {
@@ -169,7 +169,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
                             "::",
                             #schema_name_fmt
                         )
-                        #(,#type_params::schema_id())*
+                        #(,schemars::_schemars_maybe_schema_id!(#type_params))*
                         #(,#const_params)*
                     )
                 )


### PR DESCRIPTION
Fixes #373

Currently, `#[schemars(bound = "...")]` is pretty much useless unless you also specify `#[schemars(rename= "...")]`, because otherwise, the derived `JsonSchema` impl assumes that all type params implement `JsonSchema`.

This PR more gracefully handles type params that don't implement `JsonSchema` - when it needs to call `schema_id()`/`schema_name()` on those types, it will fallback to the type param name itself. e.g. as seen in the integration test, the default name for `MyContainer<T>` where `T` does not impl `JsonSchema` is now `MyContainer_for_T`.

A better fix for this would be #168, but this PR is a reasonable stopgap until that's done