### PR TITLE
Make `title` for untagged enum variants opt-in

### DIFF
--- a/docs/_includes/examples/schemars_attrs.schema.json
+++ b/docs/_includes/examples/schemars_attrs.schema.json
@@ -41,12 +41,10 @@
     "MyEnum": {
       "anyOf": [
         {
-          "title": "StringNewType",
           "type": "string",
           "format": "email"
         },
         {
-          "title": "StructVariant",
           "type": "object",
           "properties": {
             "floats": {

--- a/docs/_includes/examples/serde_attrs.schema.json
+++ b/docs/_includes/examples/serde_attrs.schema.json
@@ -31,11 +31,9 @@
     "MyEnum": {
       "anyOf": [
         {
-          "title": "StringNewType",
           "type": "string"
         },
         {
-          "title": "StructVariant",
           "type": "object",
           "properties": {
             "floats": {

--- a/schemars/examples/schemars_attrs.schema.json
+++ b/schemars/examples/schemars_attrs.schema.json
@@ -41,12 +41,10 @@
     "MyEnum": {
       "anyOf": [
         {
-          "title": "StringNewType",
           "type": "string",
           "format": "email"
         },
         {
-          "title": "StructVariant",
           "type": "object",
           "properties": {
             "floats": {

--- a/schemars/examples/serde_attrs.schema.json
+++ b/schemars/examples/serde_attrs.schema.json
@@ -31,11 +31,9 @@
     "MyEnum": {
       "anyOf": [
         {
-          "title": "StringNewType",
           "type": "string"
         },
         {
-          "title": "StructVariant",
           "type": "object",
           "properties": {
             "floats": {

--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -26,6 +26,7 @@ type CowStr = alloc::borrow::Cow<'static, str>;
 /// [`SchemaSettings::draft2020_12()`] method.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[allow(clippy::struct_excessive_bools)]
 pub struct SchemaSettings {
     /// This option is now ignored and will be removed before schemars 1.0 becomes stable.
     ///
@@ -49,6 +50,8 @@ pub struct SchemaSettings {
     /// Defaults to [`meta_schemas::DRAFT2020_12`] (`https://json-schema.org/draft/2020-12/schema`).
     pub meta_schema: Option<CowStr>,
     /// A list of [`Transform`]s that get applied to generated root schemas.
+    ///
+    /// Defaults to an empty vec (no transforms).
     pub transforms: Vec<Box<dyn GenTransform>>,
     /// Inline all subschemas instead of using references.
     ///
@@ -60,6 +63,14 @@ pub struct SchemaSettings {
     ///
     /// Defaults to `Contract::Deserialize`.
     pub contract: Contract,
+    /// Whether to include enum variant names in their schema's `title` when using the [untagged
+    /// enum representation](https://serde.rs/enum-representations.html#untagged).
+    ///
+    /// This setting is respected by `#[derive(JsonSchema)]` on enums, but manual implementations
+    /// of `JsonSchema` may ignore this setting.
+    ///
+    /// Defaults to `false`.
+    pub untagged_enum_variant_titles: bool,
 }
 
 impl Default for SchemaSettings {
@@ -87,6 +98,7 @@ impl SchemaSettings {
             ],
             inline_subschemas: false,
             contract: Contract::Deserialize,
+            untagged_enum_variant_titles: false,
         }
     }
 
@@ -101,6 +113,7 @@ impl SchemaSettings {
             transforms: vec![Box::new(ReplacePrefixItems)],
             inline_subschemas: false,
             contract: Contract::Deserialize,
+            untagged_enum_variant_titles: false,
         }
     }
 
@@ -115,6 +128,7 @@ impl SchemaSettings {
             transforms: Vec::new(),
             inline_subschemas: false,
             contract: Contract::Deserialize,
+            untagged_enum_variant_titles: false,
         }
     }
 
@@ -139,6 +153,7 @@ impl SchemaSettings {
             ],
             inline_subschemas: false,
             contract: Contract::Deserialize,
+            untagged_enum_variant_titles: false,
         }
     }
 

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~untagged_enum.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~untagged_enum.de.json
@@ -3,11 +3,9 @@
   "title": "UntaggedEnum",
   "anyOf": [
     {
-      "title": "WriteOnlyUnit",
       "type": "null"
     },
     {
-      "title": "WriteOnlyStruct",
       "type": "object",
       "properties": {
         "i": {
@@ -20,11 +18,9 @@
       ]
     },
     {
-      "title": "de_renamed_unit",
       "type": "null"
     },
     {
-      "title": "de_renamed_struct",
       "type": "object",
       "properties": {
         "b": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~untagged_enum.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~untagged_enum.ser.json
@@ -3,11 +3,9 @@
   "title": "UntaggedEnum",
   "anyOf": [
     {
-      "title": "READ-ONLY-UNIT",
       "type": "null"
     },
     {
-      "title": "READ-ONLY-STRUCT",
       "type": "object",
       "properties": {
         "S": {
@@ -19,11 +17,9 @@
       ]
     },
     {
-      "title": "ser_renamed_unit",
       "type": "null"
     },
     {
-      "title": "ser_renamed_struct",
       "type": "object",
       "properties": {
         "B": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum.json
@@ -3,26 +3,21 @@
   "title": "Untagged",
   "anyOf": [
     {
-      "title": "UnitOne",
       "type": "null"
     },
     {
-      "title": "StringMap",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
     {
-      "title": "UnitStructNewType",
       "$ref": "#/$defs/UnitStruct"
     },
     {
-      "title": "StructNewType",
       "$ref": "#/$defs/Struct"
     },
     {
-      "title": "Struct",
       "type": "object",
       "properties": {
         "foo": {
@@ -39,7 +34,6 @@
       ]
     },
     {
-      "title": "Tuple",
       "type": "array",
       "prefixItems": [
         {
@@ -54,17 +48,14 @@
       "maxItems": 2
     },
     {
-      "title": "UnitTwo",
       "type": "null"
     },
     {
-      "title": "UnitAsInt",
       "type": "integer",
       "format": "uint64",
       "minimum": 0
     },
     {
-      "title": "TupleAsStr",
       "type": "string",
       "pattern": "^\\d+ (true|false)$"
     }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum_with_titles.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~untagged_enum_with_titles.json
@@ -1,74 +1,45 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Adjacent",
+  "title": "Untagged",
   "anyOf": [
     {
-      "type": "object",
-      "properties": {
-        "tag": {
-          "type": "string",
-          "const": "TaggedUnitOne"
-        }
-      },
-      "required": [
-        "tag"
-      ]
-    },
-    {
-      "type": "object",
-      "properties": {
-        "tag": {
-          "type": "string",
-          "const": "TaggedStruct"
-        },
-        "content": {
-          "type": "object",
-          "properties": {
-            "baz": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "foobar": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "baz",
-            "foobar"
-          ]
-        }
-      },
-      "required": [
-        "tag",
-        "content"
-      ]
-    },
-    {
+      "title": "UnitOne",
       "type": "null"
     },
     {
+      "title": "StringMap",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    {
+      "title": "UnitStructNewType",
       "$ref": "#/$defs/UnitStruct"
     },
     {
+      "title": "StructNewType",
       "$ref": "#/$defs/Struct"
     },
     {
+      "title": "Struct",
       "type": "object",
       "properties": {
-        "baz": {
+        "foo": {
           "type": "integer",
           "format": "int32"
         },
-        "foobar": {
+        "bar": {
           "type": "boolean"
         }
       },
       "required": [
-        "baz",
-        "foobar"
+        "foo",
+        "bar"
       ]
     },
     {
+      "title": "Tuple",
       "type": "array",
       "prefixItems": [
         {
@@ -83,10 +54,19 @@
       "maxItems": 2
     },
     {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "title": "UnitTwo",
+      "type": "null"
+    },
+    {
+      "title": "UnitAsInt",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    {
+      "title": "TupleAsStr",
+      "type": "string",
+      "pattern": "^\\d+ (true|false)$"
     }
   ],
   "$defs": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_deny_unknown_fields.rs~untagged_enum.json
@@ -3,26 +3,21 @@
   "title": "Untagged",
   "anyOf": [
     {
-      "title": "Unit",
       "type": "null"
     },
     {
-      "title": "StringMap",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       }
     },
     {
-      "title": "StructNewType",
       "$ref": "#/$defs/Struct"
     },
     {
-      "title": "StructDenyUnknownFieldsNewType",
       "$ref": "#/$defs/StructDenyUnknownFields"
     },
     {
-      "title": "Struct",
       "type": "object",
       "properties": {
         "foo": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_untagged_variant.rs~externally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_untagged_variant.rs~externally_tagged_enum.json
@@ -34,19 +34,15 @@
       "additionalProperties": false
     },
     {
-      "title": "unitOne",
       "type": "null"
     },
     {
-      "title": "unitStructNewType",
       "$ref": "#/$defs/UnitStruct"
     },
     {
-      "title": "structNewType",
       "$ref": "#/$defs/Struct"
     },
     {
-      "title": "struct",
       "type": "object",
       "properties": {
         "baz": {
@@ -63,7 +59,6 @@
       ]
     },
     {
-      "title": "tuple",
       "type": "array",
       "prefixItems": [
         {
@@ -78,7 +73,6 @@
       "maxItems": 2
     },
     {
-      "title": "stringMap",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_untagged_variant.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_untagged_variant.rs~internally_tagged_enum.json
@@ -36,19 +36,15 @@
       ]
     },
     {
-      "title": "UnitOne",
       "type": "null"
     },
     {
-      "title": "UnitStructNewType",
       "$ref": "#/$defs/UnitStruct"
     },
     {
-      "title": "StructNewType",
       "$ref": "#/$defs/Struct"
     },
     {
-      "title": "Struct",
       "type": "object",
       "properties": {
         "baz": {
@@ -65,7 +61,6 @@
       ]
     },
     {
-      "title": "StringMap",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/extend.rs~extend_untagged_enum.json
@@ -3,16 +3,13 @@
   "title": "UntaggedEnum",
   "anyOf": [
     {
-      "title": "Unit",
       "type": "null",
       "foo": "bar"
     },
     {
-      "title": "NewType",
       "foo": "bar"
     },
     {
-      "title": "Tuple",
       "type": "array",
       "prefixItems": [
         {
@@ -28,7 +25,6 @@
       "foo": "bar"
     },
     {
-      "title": "Struct",
       "type": "object",
       "properties": {
         "i": {

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/remote_derive.rs~type_param.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/remote_derive.rs~type_param.json
@@ -18,14 +18,12 @@
     "Or_for_uint8_and_boolean": {
       "anyOf": [
         {
-          "title": "A",
           "type": "integer",
           "format": "uint8",
           "minimum": 0,
           "maximum": 255
         },
         {
-          "title": "B",
           "type": "boolean"
         }
       ]
@@ -33,11 +31,9 @@
     "Or_for_null_and_string": {
       "anyOf": [
         {
-          "title": "A",
           "type": "null"
         },
         {
-          "title": "B",
           "type": "string"
         }
       ]

--- a/schemars/tests/integration/test_helper.rs
+++ b/schemars/tests/integration/test_helper.rs
@@ -132,9 +132,11 @@ impl<T: JsonSchema> TestHelper<T> {
         self
     }
 
-    pub fn custom(&self, assertion: impl Fn(&Schema, Contract)) {
+    pub fn custom(&self, assertion: impl Fn(&Schema, Contract)) -> &Self {
         assertion(&self.de_schema, Contract::Deserialize);
         assertion(&self.ser_schema, Contract::Serialize);
+
+        self
     }
 
     fn de_schema_validate(&self, instance: &Value) -> bool {

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -458,7 +458,9 @@ fn expr_for_untagged_enum_variant(
         if variant.attrs.common.title.is_none() {
             let title = variant.name();
             schema_expr.mutators.push(quote! {
-                #SCHEMA.insert("title".to_owned(), #title.into());
+                if #GENERATOR.settings().untagged_enum_variant_titles {
+                    #SCHEMA.insert("title".to_owned(), #title.into());
+                }
             });
         }
 


### PR DESCRIPTION
Fixes #420 

With this PR, consumers who want untagged variants to have their name included in the schema's `title` property (#102) can still have that behaviour, but must enable the `untagged_enum_variant_titles` setting.