### PR TITLE
Improve automatic trait bounds

### DIFF
--- a/schemars/tests/integration/bound.rs
+++ b/schemars/tests/integration/bound.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use std::marker::PhantomData;
 
+#[derive(Default)]
 struct MyIterator;
 
 impl Iterator for MyIterator {
@@ -14,23 +15,55 @@ impl Iterator for MyIterator {
 // The default trait bounds would require T to implement JsonSchema, which MyIterator does not.
 // Ideally we wouldn't need the `bound` attribute here at all - it should be possible to better
 // infer automatic trait bounds (tracked in https://github.com/GREsau/schemars/issues/168)
-#[derive(JsonSchema, Serialize, Deserialize)]
+#[derive(JsonSchema, Serialize, Deserialize, Default)]
 #[schemars(bound = "T::Item: JsonSchema")]
 pub struct MyContainer<T>
 where
     T: Iterator,
 {
     pub associated: T::Item,
-    pub generic: PhantomData<T>,
+    pub phantom: PhantomData<T>,
+    #[serde(skip)]
+    pub _skipped: T,
 }
 
 #[test]
 fn manual_bound_set() {
     test!(MyContainer<MyIterator>)
+        // TODO with better bounds, this assertion would work:
+        // .assert_identical::<MyContainer<core::slice::Iter<&str>>>()
         .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
         .assert_allows_ser_roundtrip([MyContainer {
             associated: "test".to_owned(),
-            generic: PhantomData,
+            phantom: PhantomData,
+            _skipped: MyIterator,
+        }])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+// `T` doesn't need to impl `JsonSchema`, but `U` does
+#[derive(JsonSchema, Serialize, Deserialize, Default)]
+pub struct MyContainer2<T, U>
+where
+    T: Iterator,
+{
+    pub u: Option<U>,
+    pub phantom: PhantomData<T>,
+    #[serde(skip)]
+    pub _skipped: T,
+}
+
+#[test]
+fn auto_bound() {
+    test!(MyContainer2<MyIterator, String>)
+        .assert_identical::<MyContainer2<core::slice::Iter<&str>, Box<str>>>()
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_allows_ser_roundtrip([MyContainer2 {
+            u: Some("test".to_owned()),
+            phantom: PhantomData,
+            _skipped: MyIterator,
         }])
         .assert_matches_de_roundtrip(arbitrary_values());
 }

--- a/schemars/tests/integration/remote_derive.rs
+++ b/schemars/tests/integration/remote_derive.rs
@@ -39,6 +39,7 @@ fn simple() {
 
 #[derive(JsonSchema, Deserialize, Serialize)]
 #[serde(untagged, remote = "external::Or")]
+#[schemars(rename = "{A}_or_{B}")]
 enum OrDef<A, B> {
     A(A),
     B(B),

--- a/schemars/tests/integration/schema_name.rs
+++ b/schemars/tests/integration/schema_name.rs
@@ -40,19 +40,29 @@ struct RenamedTypeParams<T, U, V, W> {
 
 #[test]
 fn type_params() {
-    test!(TypeParams<u8, String, bool, ()>).custom(|schema, _| {
-        assert_eq!(
-            schema.get("title"),
-            Some(&"TypeParams_for_uint8_and_string_and_boolean_and_null".into())
-        )
-    });
+    test!(TypeParams<u8, String, bool, ()>)
+        .assert_allows_ser_roundtrip_default()
+        .assert_identical::<TypeParams<u8, Box<str>, bool, ()>>();
 
-    test!(RenamedTypeParams<u8, String, bool, ()>).custom(|schema, _| {
-        assert_eq!(
-            schema.get("title"),
-            Some(&"new-name-null-uint8-uint8".into())
-        )
-    });
+    assert_ne!(
+        <TypeParams<u8, String, bool, ()>>::schema_id(),
+        <TypeParams<(), u8, String, bool>>::schema_id()
+    );
+
+    test!(RenamedTypeParams<u8, String, bool, ()>)
+        .assert_allows_ser_roundtrip_default()
+        .assert_identical::<RenamedTypeParams<u8, Box<str>, bool, ()>>()
+        .custom(|schema, _| {
+            assert_eq!(
+                schema.get("title"),
+                Some(&"new-name-null-uint8-uint8".into())
+            )
+        });
+
+    assert_ne!(
+        <RenamedTypeParams<u8, String, bool, ()>>::schema_id(),
+        <RenamedTypeParams<(), u8, String, bool>>::schema_id()
+    );
 }
 
 #[derive(JsonSchema, Deserialize, Serialize, Default)]
@@ -62,7 +72,7 @@ struct ConstGeneric<const INT: usize, const CHAR: char> {
 }
 
 #[derive(JsonSchema, Deserialize, Serialize, Default)]
-#[schemars(rename = "new-name-{INT}")]
+#[schemars(rename = "{{new-name-{INT}}}")]
 struct RenamedConstGeneric<const INT: usize, const CHAR: char> {
     #[schemars(range(max = INT))]
     foo: i32,
@@ -70,13 +80,19 @@ struct RenamedConstGeneric<const INT: usize, const CHAR: char> {
 
 #[test]
 fn const_generics() {
-    test!(ConstGeneric<123, 'X'>).custom(|schema, _| {
-        assert_eq!(
-            schema.get("title"),
-            Some(&"ConstGeneric_for_123_and_X".into())
-        )
-    });
+    test!(ConstGeneric<123, 'X'>).assert_allows_ser_roundtrip_default();
+
+    assert_ne!(
+        <ConstGeneric<123, 'X'>>::schema_id(),
+        <ConstGeneric<321, 'Y'>>::schema_id()
+    );
 
     test!(RenamedConstGeneric<123, 'X'>)
-        .custom(|schema, _| assert_eq!(schema.get("title"), Some(&"new-name-123".into())));
+        .assert_allows_ser_roundtrip_default()
+        .custom(|schema, _| assert_eq!(schema.get("title"), Some(&"{new-name-123}".into())));
+
+    assert_ne!(
+        <RenamedConstGeneric<123, 'X'>>::schema_id(),
+        <RenamedConstGeneric<321, 'Y'>>::schema_id()
+    );
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~auto_bound.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~auto_bound.de.json
@@ -1,17 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "MyContainer",
+  "title": "MyContainer2",
   "type": "object",
   "properties": {
-    "associated": {
-      "type": "string"
+    "u": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "phantom": {
       "type": "null"
     }
   },
   "required": [
-    "associated",
     "phantom"
   ]
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~auto_bound.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/bound.rs~auto_bound.ser.json
@@ -1,17 +1,20 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "MyContainer",
+  "title": "MyContainer2",
   "type": "object",
   "properties": {
-    "associated": {
-      "type": "string"
+    "u": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "phantom": {
       "type": "null"
     }
   },
   "required": [
-    "associated",
+    "u",
     "phantom"
   ]
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/remote_derive.rs~type_param.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/remote_derive.rs~type_param.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "TypeParam_for_string",
+  "title": "TypeParam",
   "type": "object",
   "properties": {
     "byte_or_bool": {
-      "$ref": "#/$defs/Or_for_uint8_and_boolean"
+      "$ref": "#/$defs/uint8_or_boolean"
     },
     "unit_or_t": {
-      "$ref": "#/$defs/Or_for_null_and_string"
+      "$ref": "#/$defs/null_or_string"
     }
   },
   "required": [
@@ -15,7 +15,7 @@
     "unit_or_t"
   ],
   "$defs": {
-    "Or_for_uint8_and_boolean": {
+    "uint8_or_boolean": {
       "anyOf": [
         {
           "type": "integer",
@@ -28,7 +28,7 @@
         }
       ]
     },
-    "Or_for_null_and_string": {
+    "null_or_string": {
       "anyOf": [
         {
           "type": "null"

--- a/schemars/tests/ui/invalid_rename.rs
+++ b/schemars/tests/ui/invalid_rename.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+
+struct DoesNotImplJsonSchema;
+
+#[derive(JsonSchema)]
+#[schemars(rename = "} } {T} {U} {T::test} } {T")]
+pub struct Struct1<T> {
+    pub t: T,
+}
+
+fn main() {}

--- a/schemars/tests/ui/invalid_rename.stderr
+++ b/schemars/tests/ui/invalid_rename.stderr
@@ -1,0 +1,23 @@
+error: invalid name format string: unmatched `}` found
+ --> tests/ui/invalid_rename.rs:6:21
+  |
+6 | #[schemars(rename = "} } {T} {U} {T::test} } {T")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid name format string: expected generic param, found `U`
+ --> tests/ui/invalid_rename.rs:6:21
+  |
+6 | #[schemars(rename = "} } {T} {U} {T::test} } {T")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid name format string: expected generic param, found `T::test`
+ --> tests/ui/invalid_rename.rs:6:21
+  |
+6 | #[schemars(rename = "} } {T} {U} {T::test} } {T")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid name format string: found `{` without matching `}`
+ --> tests/ui/invalid_rename.rs:6:21
+  |
+6 | #[schemars(rename = "} } {T} {U} {T::test} } {T")]
+  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/schemars_derive/src/ast/from_serde.rs
+++ b/schemars_derive/src/ast/from_serde.rs
@@ -1,75 +1,78 @@
 use super::*;
+use crate::name::get_rename_format_type_params;
 use serde_derive_internals::ast as serde_ast;
 use serde_derive_internals::Ctxt;
 
 pub trait FromSerde: Sized {
     type SerdeType;
 
-    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Result<Self, ()>;
+    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self;
 
-    fn vec_from_serde(errors: &Ctxt, serdes: Vec<Self::SerdeType>) -> Result<Vec<Self>, ()> {
-        let mut result = Vec::with_capacity(serdes.len());
-        for s in serdes {
-            result.push(Self::from_serde(errors, s)?)
-        }
-        Ok(result)
+    fn vec_from_serde(errors: &Ctxt, serdes: Vec<Self::SerdeType>) -> Vec<Self> {
+        serdes
+            .into_iter()
+            .map(|s| Self::from_serde(errors, s))
+            .collect()
     }
 }
 
 impl<'a> FromSerde for Container<'a> {
     type SerdeType = serde_ast::Container<'a>;
 
-    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Result<Self, ()> {
-        Ok(Self {
+    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self {
+        let mut result = Self {
             ident: serde.ident,
             serde_attrs: serde.attrs,
-            data: Data::from_serde(errors, serde.data)?,
-            generics: serde.generics.clone(),
+            data: Data::from_serde(errors, serde.data),
+            generics: serde.generics,
             attrs: ContainerAttrs::new(&serde.original.attrs, errors),
-        })
+            rename_type_params: BTreeSet::new(),
+        };
+        result.rename_type_params = get_rename_format_type_params(errors, &result);
+        result
     }
 }
 
 impl<'a> FromSerde for Data<'a> {
     type SerdeType = serde_ast::Data<'a>;
 
-    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Result<Self, ()> {
-        Ok(match serde {
+    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self {
+        match serde {
             serde_ast::Data::Enum(variants) => {
-                Data::Enum(Variant::vec_from_serde(errors, variants)?)
+                Data::Enum(Variant::vec_from_serde(errors, variants))
             }
             serde_ast::Data::Struct(style, fields) => {
-                Data::Struct(style, Field::vec_from_serde(errors, fields)?)
+                Data::Struct(style, Field::vec_from_serde(errors, fields))
             }
-        })
+        }
     }
 }
 
 impl<'a> FromSerde for Variant<'a> {
     type SerdeType = serde_ast::Variant<'a>;
 
-    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Result<Self, ()> {
-        Ok(Self {
+    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self {
+        Self {
             ident: serde.ident,
             serde_attrs: serde.attrs,
             style: serde.style,
-            fields: Field::vec_from_serde(errors, serde.fields)?,
+            fields: Field::vec_from_serde(errors, serde.fields),
             original: serde.original,
             attrs: VariantAttrs::new(&serde.original.attrs, errors),
-        })
+        }
     }
 }
 
 impl<'a> FromSerde for Field<'a> {
     type SerdeType = serde_ast::Field<'a>;
 
-    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Result<Self, ()> {
-        Ok(Self {
+    fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self {
+        Self {
             member: serde.member,
             serde_attrs: serde.attrs,
             ty: serde.ty,
             original: serde.original,
             attrs: FieldAttrs::new(&serde.original.attrs, errors),
-        })
+        }
     }
 }

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -40,7 +40,7 @@ pub struct ContainerAttrs {
     pub common: CommonAttrs,
     pub repr: Option<Type>,
     pub crate_name: Option<Path>,
-    // Bhe actual parsing of this is done in `get_rename_format_type_params()`,
+    // The actual parsing of this is done in `get_rename_format_type_params()`,
     // because it depends on the type's generic params.
     pub rename_format_string: Option<LitStr>,
     pub inline: bool,

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -4,13 +4,13 @@ mod schemars_to_serde;
 mod validation;
 
 use parse_meta::{
-    parse_extensions, parse_name_value_expr, parse_name_value_lit_str, require_path_only,
+    parse_extensions, parse_name_value_expr, parse_name_value_lit_str, require_name_value_lit_str,
+    require_path_only,
 };
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use serde_derive_internals::Ctxt;
-use syn::Ident;
-use syn::{punctuated::Punctuated, Attribute, Expr, ExprLit, Lit, Meta, Path, Type};
+use syn::{punctuated::Punctuated, Attribute, Expr, ExprLit, Ident, Lit, LitStr, Meta, Path, Type};
 use validation::ValidationAttrs;
 
 use crate::idents::SCHEMA;
@@ -40,7 +40,9 @@ pub struct ContainerAttrs {
     pub common: CommonAttrs,
     pub repr: Option<Type>,
     pub crate_name: Option<Path>,
-    pub is_renamed: bool,
+    // Bhe actual parsing of this is done in `get_rename_format_type_params()`,
+    // because it depends on the type's generic params.
+    pub rename_format_string: Option<LitStr>,
     pub inline: bool,
 }
 
@@ -308,8 +310,10 @@ impl ContainerAttrs {
                 None => self.crate_name = parse_name_value_lit_str(meta, cx).ok(),
             },
 
-            // The actual parsing of `rename` is done by serde
-            "rename" => self.is_renamed = true,
+            "rename" if cx.attr_type == "schemars" => match self.rename_format_string {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.rename_format_string = require_name_value_lit_str(meta, cx).ok(),
+            },
 
             "inline" => {
                 if self.inline {

--- a/schemars_derive/src/attr/parse_meta.rs
+++ b/schemars_derive/src/attr/parse_meta.rs
@@ -58,7 +58,7 @@ pub fn parse_name_value_expr(meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
     }
 }
 
-pub fn parse_name_value_lit_str<T: Parse>(meta: Meta, cx: &AttrCtxt) -> Result<T, ()> {
+pub fn require_name_value_lit_str(meta: Meta, cx: &AttrCtxt) -> Result<LitStr, ()> {
     let Meta::NameValue(MetaNameValue {
         value: Expr::Lit(ExprLit {
             lit: Lit::Str(lit_str),
@@ -77,6 +77,12 @@ pub fn parse_name_value_lit_str<T: Parse>(meta: Meta, cx: &AttrCtxt) -> Result<T
         );
         return Err(());
     };
+
+    Ok(lit_str)
+}
+
+pub fn parse_name_value_lit_str<T: Parse>(meta: Meta, cx: &AttrCtxt) -> Result<T, ()> {
+    let lit_str = require_name_value_lit_str(meta, cx)?;
 
     parse_lit_str(lit_str, cx)
 }

--- a/schemars_derive/src/bound.rs
+++ b/schemars_derive/src/bound.rs
@@ -1,0 +1,302 @@
+use crate::{
+    ast::{Container, Data, Field, Variant},
+    attr::WithAttr,
+};
+use std::collections::BTreeSet;
+use syn::{punctuated::Punctuated, Ident};
+
+// This logic is heavily based on serde_derive:
+// https://github.com/serde-rs/serde/blob/a1ddb18c92f32d64b2ccaf31ddd776e56be34ba2/serde_derive/src/bound.rs#L91
+
+/// Returns a tuple of:
+/// 1. The `where` clause to be included on the `JsonSchema` impl
+/// 2. A `BTreeSet` of type params that are "relevant" to the impl, i.e. excluding params only used
+///    in `PhantomData` or skipped fields
+pub fn find_trait_bounds<'a>(
+    cont: &'a Container<'a>,
+) -> (Option<syn::WhereClause>, BTreeSet<&'a Ident>) {
+    if cont.generics.params.is_empty() {
+        return (cont.generics.where_clause.clone(), BTreeSet::new());
+    }
+
+    let all_type_params =
+        BTreeSet::from_iter(cont.generics.type_params().map(|param| &param.ident));
+
+    assert!(cont.rename_type_params.is_subset(&all_type_params));
+
+    let mut visitor = FindTyParams {
+        all_type_params,
+        relevant_type_params: cont.rename_type_params.clone(),
+    };
+
+    if visitor.all_type_params.len() > visitor.relevant_type_params.len() {
+        match &cont.data {
+            Data::Enum(variants) => {
+                for variant in variants {
+                    let relevant_fields = variant
+                        .fields
+                        .iter()
+                        .filter(|field| needs_jsonschema_bound(field, Some(variant)));
+                    for field in relevant_fields {
+                        visitor.visit_field(field);
+                    }
+                }
+            }
+            Data::Struct(_, fields) => {
+                let relevant_fields = fields
+                    .iter()
+                    .filter(|field| needs_jsonschema_bound(field, None));
+                for field in relevant_fields {
+                    visitor.visit_field(field);
+                }
+            }
+        }
+    }
+
+    let mut where_clause = cont
+        .generics
+        .where_clause
+        .clone()
+        .unwrap_or_else(|| syn::WhereClause {
+            where_token: <Token![where]>::default(),
+            predicates: Punctuated::default(),
+        });
+
+    if let Some(bounds) = cont.serde_attrs.de_bound() {
+        where_clause.predicates.extend(bounds.iter().cloned());
+    } else {
+        where_clause
+            .predicates
+            .extend(visitor.relevant_type_params.iter().map(|ty| {
+                syn::WherePredicate::Type(syn::PredicateType {
+                    lifetimes: None,
+                    bounded_ty: syn::Type::Path(syn::TypePath {
+                        qself: None,
+                        path: syn::Path {
+                            leading_colon: None,
+                            segments: Punctuated::from_iter([syn::PathSegment {
+                                ident: (*ty).clone(),
+                                arguments: syn::PathArguments::None,
+                            }]),
+                        },
+                    }),
+                    colon_token: <Token![:]>::default(),
+                    bounds: Punctuated::from_iter([syn::TypeParamBound::Trait(syn::TraitBound {
+                        paren_token: None,
+                        modifier: syn::TraitBoundModifier::None,
+                        lifetimes: None,
+                        path: parse_quote!(schemars::JsonSchema),
+                    })]),
+                })
+            }));
+    }
+
+    (Some(where_clause), visitor.relevant_type_params)
+}
+
+fn needs_jsonschema_bound(field: &Field, variant: Option<&Variant>) -> bool {
+    if let Some(variant) = variant {
+        if variant.serde_attrs.skip_deserializing() && variant.serde_attrs.skip_serializing() {
+            return false;
+        }
+    }
+    if field.serde_attrs.skip_deserializing() && field.serde_attrs.skip_serializing() {
+        return false;
+    }
+
+    true
+}
+
+struct FindTyParams<'ast> {
+    all_type_params: BTreeSet<&'ast Ident>,
+    relevant_type_params: BTreeSet<&'ast Ident>,
+}
+
+impl<'ast> FindTyParams<'ast> {
+    fn visit_field(&mut self, field: &'ast Field) {
+        match &field.attrs.with {
+            Some(WithAttr::Type(ty)) => self.visit_type(ty),
+            Some(WithAttr::Function(f)) => self.visit_path(f),
+            None => self.visit_type(&field.original.ty),
+        }
+    }
+
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        if let Some(seg) = path.segments.last() {
+            if seg.ident == "PhantomData" {
+                // Hardcoded exception, because PhantomData<T> implements
+                // JsonSchema whether or not T implements it.
+                return;
+            }
+        }
+
+        if path.leading_colon.is_none() {
+            if let Some(first_segment) = path.segments.first() {
+                let id = &first_segment.ident;
+                if self.all_type_params.contains(id) {
+                    self.relevant_type_params.insert(id);
+                }
+            }
+        }
+
+        for segment in &path.segments {
+            self.visit_path_segment(segment);
+        }
+    }
+
+    fn visit_type(&mut self, ty: &'ast syn::Type) {
+        match ty {
+            syn::Type::Array(ty) => self.visit_type(&ty.elem),
+            syn::Type::BareFn(ty) => {
+                for arg in &ty.inputs {
+                    self.visit_type(&arg.ty);
+                }
+                self.visit_return_type(&ty.output);
+            }
+            syn::Type::Group(ty) => self.visit_type(&ty.elem),
+            syn::Type::ImplTrait(ty) => {
+                for bound in &ty.bounds {
+                    self.visit_type_param_bound(bound);
+                }
+            }
+            syn::Type::Macro(ty) => self.visit_macro(&ty.mac),
+            syn::Type::Paren(ty) => self.visit_type(&ty.elem),
+            syn::Type::Path(ty) => {
+                if let Some(qself) = &ty.qself {
+                    self.visit_type(&qself.ty);
+                }
+                self.visit_path(&ty.path);
+            }
+            syn::Type::Ptr(ty) => self.visit_type(&ty.elem),
+            syn::Type::Reference(ty) => {
+                self.visit_type(&ty.elem);
+            }
+            syn::Type::Slice(ty) => self.visit_type(&ty.elem),
+            syn::Type::TraitObject(ty) => {
+                for bound in &ty.bounds {
+                    self.visit_type_param_bound(bound);
+                }
+            }
+            syn::Type::Tuple(ty) => {
+                for elem in &ty.elems {
+                    self.visit_type(elem);
+                }
+            }
+
+            syn::Type::Infer(_) | syn::Type::Never(_) | syn::Type::Verbatim(_) => {}
+
+            _ => {}
+        }
+    }
+
+    fn visit_path_segment(&mut self, segment: &'ast syn::PathSegment) {
+        self.visit_path_arguments(&segment.arguments)
+    }
+
+    fn visit_path_arguments(&mut self, arguments: &'ast syn::PathArguments) {
+        match arguments {
+            syn::PathArguments::None => {}
+            syn::PathArguments::AngleBracketed(arguments) => {
+                for arg in &arguments.args {
+                    match arg {
+                        syn::GenericArgument::Type(arg) => self.visit_type(arg),
+                        syn::GenericArgument::AssocType(arg) => self.visit_type(&arg.ty),
+                        syn::GenericArgument::Lifetime(_)
+                        | syn::GenericArgument::Const(_)
+                        | syn::GenericArgument::AssocConst(_)
+                        | syn::GenericArgument::Constraint(_) => {}
+                        _ => {}
+                    }
+                }
+            }
+            syn::PathArguments::Parenthesized(arguments) => {
+                for argument in &arguments.inputs {
+                    self.visit_type(argument);
+                }
+                self.visit_return_type(&arguments.output);
+            }
+        }
+    }
+
+    fn visit_return_type(&mut self, return_type: &'ast syn::ReturnType) {
+        match return_type {
+            syn::ReturnType::Default => {}
+            syn::ReturnType::Type(_, output) => self.visit_type(output),
+        }
+    }
+
+    fn visit_type_param_bound(&mut self, bound: &'ast syn::TypeParamBound) {
+        match bound {
+            syn::TypeParamBound::Trait(bound) => self.visit_path(&bound.path),
+            syn::TypeParamBound::Lifetime(_)
+            | syn::TypeParamBound::PreciseCapture(_)
+            | syn::TypeParamBound::Verbatim(_) => {}
+            _ => {}
+        }
+    }
+
+    // Type parameter should not be considered used by a macro path.
+    //
+    //     struct TypeMacro<T> {
+    //         mac: T!(),
+    //         marker: PhantomData<T>,
+    //     }
+    fn visit_macro(&mut self, _mac: &'ast syn::Macro) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_enum_bounds() {
+        // All type params should be included in `JsonSchema` trait bounds except `Z`
+        let input = parse_quote! {
+            #[schemars(rename = "MyEnum<{T}, {U}, {V}, {W}, {X}, {Y}, {{Z}}>")]
+            pub enum MyEnum<'a, const LEN: usize, T, U, V, W, X, Y, Z>
+            where
+                X: Trait,
+                Z: OtherTrait
+            {
+                A,
+                B(),
+                C(T),
+                D(U, (i8, V, bool)),
+                E {
+                    a: W,
+                    b: [&'a Option<Box<<X as Trait>::AssocType::Z>>; LEN],
+                    c: Token![Z],
+                    d: PhantomData<Z>,
+                    #[serde(skip)]
+                    e: Z,
+                },
+                #[serde(skip)]
+                F(Z),
+            }
+        };
+
+        let cont = Container::from_ast(&input).unwrap();
+
+        let (where_clause, relevant_type_params) = find_trait_bounds(&cont);
+
+        assert_eq!(
+            where_clause,
+            Some(parse_quote!(
+                where
+                    X: Trait,
+                    Z: OtherTrait,
+                    T: schemars::JsonSchema,
+                    U: schemars::JsonSchema,
+                    V: schemars::JsonSchema,
+                    W: schemars::JsonSchema,
+                    X: schemars::JsonSchema,
+                    Y: schemars::JsonSchema
+            ))
+        );
+
+        let relevant_type_params =
+            Vec::from_iter(relevant_type_params.into_iter().map(Ident::to_string));
+        assert_eq!(relevant_type_params, vec!["T", "U", "V", "W", "X", "Y"]);
+    }
+}

--- a/schemars_derive/src/idents.rs
+++ b/schemars_derive/src/idents.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::TokenStreamExt;
 
 pub const GENERATOR: ConstIdent = ConstIdent("generator");
@@ -10,6 +10,6 @@ pub struct ConstIdent(&'static str);
 impl quote::ToTokens for ConstIdent {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ident = Ident::new(self.0, Span::call_site());
-        tokens.append(TokenTree::from(ident));
+        tokens.append(ident);
     }
 }

--- a/schemars_derive/src/name.rs
+++ b/schemars_derive/src/name.rs
@@ -1,0 +1,79 @@
+use crate::ast::Container;
+use serde_derive_internals::Ctxt;
+use std::collections::{BTreeMap, BTreeSet};
+use syn::Ident;
+
+pub fn get_rename_format_type_params<'a>(
+    errors: &Ctxt,
+    cont: &Container<'a>,
+) -> BTreeSet<&'a Ident> {
+    let mut type_params = BTreeSet::new();
+
+    let Some(lit_str) = &cont.attrs.rename_format_string else {
+        return type_params;
+    };
+
+    let mut format_str = lit_str.value();
+
+    if !format_str.contains('{') {
+        return type_params;
+    }
+
+    if format_str.contains("{{") {
+        format_str = format_str.replace("{{", "");
+    }
+
+    if format_str.contains("}}") {
+        format_str = format_str.replace("}}", "");
+    }
+
+    let all_const_params =
+        BTreeSet::from_iter(cont.generics.const_params().map(|c| c.ident.to_string()));
+    let all_type_params = BTreeMap::from_iter(
+        cont.generics
+            .type_params()
+            .map(|c| (c.ident.to_string(), &c.ident)),
+    );
+
+    let mut segments = format_str.split('{');
+
+    if segments.next().unwrap_or_default().contains('}') {
+        // The name format string contains a '}' before the first '{'
+        errors.error_spanned_by(lit_str, "invalid name format string: unmatched `}` found");
+    }
+
+    for segment in segments {
+        match segment.split_once('}') {
+            Some((param, rest)) => {
+                if rest.contains('}') {
+                    errors.error_spanned_by(
+                        lit_str,
+                        "invalid name format string: unmatched `}` found",
+                    );
+                }
+
+                if let Some(type_param) = all_type_params.get(param) {
+                    type_params.insert(type_param);
+                } else if all_const_params.contains(param) {
+                    // Any const params will be magically picked up from the surrounding scope by
+                    // `format!()`
+                } else {
+                    errors.error_spanned_by(
+                        lit_str,
+                        format_args!(
+                            "invalid name format string: expected generic param, found `{param}`"
+                        ),
+                    )
+                }
+            }
+            None => {
+                errors.error_spanned_by(
+                    lit_str,
+                    "invalid name format string: found `{` without matching `}`",
+                );
+            }
+        }
+    }
+
+    type_params
+}


### PR DESCRIPTION
Fixes #373 in a better way than #419 did. With this change, the example in #373 no longer needs an explicit `bound` attribute

- Type params that are only used in skipped fields or `PhantomData` no longer have an unnecessary `JsonSchema` bound automatically added
- Remove type params from default `schema_name()` whether or not they impl `JsonSchema`. Type params can still be included in the name by specifying them in a `rename` attribute
- Accept non-`JsonSchema` type params in `schema_id()`