### PR TITLE
Add support for serializing heterogeneous arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,9 +390,14 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "icu_collections"
@@ -771,6 +788,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1008,7 @@ dependencies = [
  "dyn-clone",
  "either",
  "garde",
+ "hashbrown",
  "indexmap",
  "jiff",
  "jsonschema",
@@ -992,6 +1019,7 @@ dependencies = [
  "schemars_derive",
  "semver",
  "serde",
+ "serde-value",
  "serde_json",
  "serde_repr",
  "smallvec",
@@ -1036,6 +1064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -13,11 +13,13 @@ categories = ["encoding", "no-std"]
 rust-version = "1.74"
 
 [dependencies]
+dyn-clone = "1.0"
+hashbrown = "0.15"
+ref-cast = "1.0.22"
 schemars_derive = { version = "=1.0.0-alpha.21", optional = true, path = "../schemars_derive" }
 serde = { version = "1.0", default-features = false, features = ["alloc"]}
+serde-value = "0.7"
 serde_json = { version =  "1.0.127", default-features = false, features = ["alloc"] }
-dyn-clone = "1.0"
-ref-cast = "1.0.22"
 
 # optional dependencies
 arrayvec07 = { version = "0.7", default-features = false, optional = true, package = "arrayvec" }

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -61,7 +61,7 @@ use serde_json::{Map, Value};
 ///
 /// let bool_schema: Schema = true.into();
 /// ```
-#[derive(Debug, Clone, PartialEq, RefCastCustom)]
+#[derive(Debug, Clone, PartialEq, Eq, RefCastCustom, Hash)]
 #[repr(transparent)]
 pub struct Schema(Value);
 

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~json_value.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~json_value.json
@@ -23,7 +23,16 @@
         },
         "mixed": {
           "type": "array",
-          "items": true
+          "items": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
When trying to deduce a schema from a value, sequences with mixed types are specified with no items information.

Modify the serialization functionality to use oneOf in case of different array elements types. While deducing schemas may treat tuples as arrays, that's still better than not deducing any sub-schemas at all.

This addresses https://github.com/GREsau/schemars/issues/348.