### PR TITLE
Prefer `oneOf` when generating schema for serialized mixed-type sequences

### DIFF
--- a/schemars/tests/integration/from_value.rs
+++ b/schemars/tests/integration/from_value.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use schemars::generate::SchemaSettings;
 use std::collections::BTreeMap;
 
-#[derive(JsonSchema, Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MyStruct {
     pub my_int: i32,
@@ -15,7 +15,7 @@ pub struct MyStruct {
     pub skip_if_none: Option<MyEnum>,
 }
 
-#[derive(JsonSchema, Deserialize, Serialize, Default, Clone)]
+#[derive(Deserialize, Serialize, Default, Clone)]
 pub struct MyInnerStruct {
     pub my_map: BTreeMap<String, f64>,
     pub my_vec: Vec<f32>,

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~json_value.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/from_value.rs~json_value.json
@@ -23,7 +23,16 @@
         },
         "mixed": {
           "type": "array",
-          "items": true
+          "items": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
Addresses #348