### PR TITLE
Allow "unsetting" serde attribute items, using a `!` prefix

### DIFF
--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -4,6 +4,18 @@ You can add attributes to your types to customize Schemars's derived `JsonSchema
 
 [Serde](https://serde.rs/) allows setting `#[serde(...)]` attributes which change how types are serialized, and Schemars will generally respect these attributes to ensure that generated schemas will match how the type is serialized by serde_json. `#[serde(...)]` attributes can be overriden using `#[schemars(...)]` attributes, which behave identically (e.g. `#[schemars(rename_all = "camelCase")]`). You may find this useful if you want to change the generated schema without affecting Serde's behaviour, or if you're just not using Serde.
 
+You can also "unset" serde attributes by including them with a `!` prefix in a schemars attribute, which will make schemars ignore the corresponding serde attribute item:
+
+```rust
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(from = "OtherType")]
+// this makes schemars ignore the `from = "OtherType"` from the serde attribute:
+#[schemars(!from)]
+pub struct MyStruct {
+    // ...
+}
+```
+
 [Validator](https://github.com/Keats/validator) and [Garde](https://github.com/jprochazk/garde) allow setting `#[validate(...)]`/`#[garde(...)]` attributes to restrict valid values of particular fields, many of which will be used by Schemars to generate more accurate schemas. These can also be overridden by `#[schemars(...)]` attributes.
 
 <details open>

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -50,6 +50,7 @@ mod std_types;
 mod structs;
 mod transform;
 mod transparent;
+mod unset;
 #[cfg(feature = "url2")]
 mod url;
 #[cfg(feature = "uuid1")]

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/unset.rs~unset_attributes.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/unset.rs~unset_attributes.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Struct",
+  "type": "object",
+  "properties": {
+    "field": {
+      "description": "Documentation for field",
+      "type": "string"
+    }
+  },
+  "required": [
+    "field"
+  ]
+}

--- a/schemars/tests/integration/unset.rs
+++ b/schemars/tests/integration/unset.rs
@@ -1,0 +1,39 @@
+use crate::prelude::*;
+
+#[derive(Default, Deserialize, Serialize, JsonSchema)]
+#[serde(from = "FlatStruct", rename_all = "kebab-case")]
+#[schemars(!from)]
+pub struct Struct {
+    #[serde(flatten)]
+    inner: Inner,
+}
+
+#[derive(Default, Deserialize, Serialize, JsonSchema)]
+pub struct Inner {
+    /// Documentation for field
+    pub field: String,
+}
+
+#[derive(Deserialize)]
+pub struct FlatStruct {
+    pub field: String,
+}
+
+impl From<FlatStruct> for Struct {
+    fn from(value: FlatStruct) -> Self {
+        Self {
+            inner: Inner { field: value.field },
+        }
+    }
+}
+
+#[test]
+fn unset_attributes() {
+    test!(Struct)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_matches_de_roundtrip(arbitrary_values_except(
+            Value::is_array,
+            "structs with `#derive(Deserialize)` can technically be deserialized from sequences, but that's not intended to be used via JSON, so schemars ignores it",
+        ));
+}

--- a/schemars/tests/ui/invalid_attrs.rs
+++ b/schemars/tests/ui/invalid_attrs.rs
@@ -10,7 +10,8 @@ use schemars::JsonSchema;
     inline,
     inline,
     with = "String",
-    serialize_with = "String"
+    serialize_with = "String",
+    a::path
 )]
 pub struct Struct1 {
     #[serde(serialize_with = "u64")]
@@ -27,7 +28,8 @@ pub struct Struct1 {
     inline,
     inline,
     with = "String",
-    serialize_with = "String"
+    serialize_with = "String",
+    a::path
 )]
 pub struct Struct2 {
     #[schemars(serialize_with = "u64")]

--- a/schemars/tests/ui/invalid_attrs.stderr
+++ b/schemars/tests/ui/invalid_attrs.stderr
@@ -17,43 +17,49 @@ error: unknown serde container attribute `with`
    |     ^^^^
 
 error: expected serde default attribute to be a string: `default = "..."`
-  --> tests/ui/invalid_attrs.rs:22:15
+  --> tests/ui/invalid_attrs.rs:23:15
    |
-22 |     default = 0,
+23 |     default = 0,
    |               ^
 
 error: duplicate serde attribute `deny_unknown_fields`
-  --> tests/ui/invalid_attrs.rs:25:5
+  --> tests/ui/invalid_attrs.rs:26:5
    |
-25 |     deny_unknown_fields,
+26 |     deny_unknown_fields,
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: unknown schemars attribute `serialize_with`
-  --> tests/ui/invalid_attrs.rs:33:16
+  --> tests/ui/invalid_attrs.rs:35:16
    |
-33 |     #[schemars(serialize_with = "u64")]
+35 |     #[schemars(serialize_with = "u64")]
    |                ^^^^^^^^^^^^^^
 
 error: unexpected value of schemars inline attribute item
-  --> tests/ui/invalid_attrs.rs:26:12
+  --> tests/ui/invalid_attrs.rs:27:12
    |
-26 |     inline = 1,
-   |            ^^^
+27 |     inline = 1,
+   |            ^
 
 error: duplicate schemars attribute item `inline`
-  --> tests/ui/invalid_attrs.rs:28:5
+  --> tests/ui/invalid_attrs.rs:29:5
    |
-28 |     inline,
+29 |     inline,
    |     ^^^^^^
 
 error: unknown schemars attribute `foo`
-  --> tests/ui/invalid_attrs.rs:23:5
+  --> tests/ui/invalid_attrs.rs:24:5
    |
-23 |     foo,
+24 |     foo,
    |     ^^^
 
 error: unknown schemars attribute `serialize_with`
-  --> tests/ui/invalid_attrs.rs:30:5
+  --> tests/ui/invalid_attrs.rs:31:5
    |
-30 |     serialize_with = "String"
+31 |     serialize_with = "String",
    |     ^^^^^^^^^^^^^^
+
+error: unknown schemars attribute `a::path`
+  --> tests/ui/invalid_attrs.rs:32:5
+   |
+32 |     a::path
+   |     ^^^^^^^

--- a/schemars/tests/ui/invalid_unset_attrs.rs
+++ b/schemars/tests/ui/invalid_unset_attrs.rs
@@ -1,0 +1,8 @@
+use schemars::JsonSchema;
+
+#[derive(JsonSchema)]
+#[serde(deny_unknown_fields, default)]
+#[schemars(!unknown, deny_unknown_fields, !deny_unknown_fields, !default, !default, !from)]
+pub struct Struct1;
+
+fn main() {}

--- a/schemars/tests/ui/invalid_unset_attrs.stderr
+++ b/schemars/tests/ui/invalid_unset_attrs.stderr
@@ -1,0 +1,23 @@
+error: duplicate schemars attribute item `!default`
+ --> tests/ui/invalid_unset_attrs.rs:5:75
+  |
+5 | #[schemars(!unknown, deny_unknown_fields, !deny_unknown_fields, !default, !default, !from)]
+  |                                                                           ^^^^^^^^
+
+error: schemars attribute cannot contain both `deny_unknown_fields` and `!deny_unknown_fields`
+ --> tests/ui/invalid_unset_attrs.rs:5:43
+  |
+5 | #[schemars(!unknown, deny_unknown_fields, !deny_unknown_fields, !default, !default, !from)]
+  |                                           ^^^^^^^^^^^^^^^^^^^^
+
+error: useless `!from` - no serde attribute containing `from` is present
+ --> tests/ui/invalid_unset_attrs.rs:5:85
+  |
+5 | #[schemars(!unknown, deny_unknown_fields, !deny_unknown_fields, !default, !default, !from)]
+  |                                                                                     ^^^^^
+
+error: useless `!unknown` - no serde attribute containing `unknown` is present
+ --> tests/ui/invalid_unset_attrs.rs:5:12
+  |
+5 | #[schemars(!unknown, deny_unknown_fields, !deny_unknown_fields, !default, !default, !from)]
+  |            ^^^^^^^^

--- a/schemars/tests/ui/invalid_validation_attrs.stderr
+++ b/schemars/tests/ui/invalid_validation_attrs.stderr
@@ -92,7 +92,7 @@ error: unexpected value of schemars email attribute item
   --> tests/ui/invalid_validation_attrs.rs:34:15
    |
 34 |         email = "foo",
-   |               ^^^^^^^
+   |               ^
 
 error: duplicate schemars attribute item `email`
   --> tests/ui/invalid_validation_attrs.rs:36:9

--- a/schemars_derive/src/attr/custom_meta.rs
+++ b/schemars_derive/src/attr/custom_meta.rs
@@ -1,12 +1,13 @@
 use quote::ToTokens;
 use syn::{parse::Parse, Meta, MetaList, MetaNameValue, Path};
 
+// An extended copy of `syn::Meta` with an additional `Not` variant
 #[derive(Debug, Clone)]
 pub enum CustomMeta {
-    Not(Token![!], Path),
     Path(Path),
     List(MetaList),
     NameValue(MetaNameValue),
+    Not(Token![!], Path),
 }
 
 impl ToTokens for CustomMeta {

--- a/schemars_derive/src/attr/custom_meta.rs
+++ b/schemars_derive/src/attr/custom_meta.rs
@@ -1,0 +1,55 @@
+use quote::ToTokens;
+use syn::{parse::Parse, Meta, MetaList, MetaNameValue, Path};
+
+#[derive(Debug, Clone)]
+pub enum CustomMeta {
+    Not(Token![!], Path),
+    Path(Path),
+    List(MetaList),
+    NameValue(MetaNameValue),
+}
+
+impl ToTokens for CustomMeta {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            CustomMeta::Not(not, path) => {
+                not.to_tokens(tokens);
+                path.to_tokens(tokens);
+            }
+            CustomMeta::Path(meta) => meta.to_tokens(tokens),
+            CustomMeta::List(meta) => meta.to_tokens(tokens),
+            CustomMeta::NameValue(meta) => meta.to_tokens(tokens),
+        }
+    }
+}
+
+impl From<Meta> for CustomMeta {
+    fn from(value: Meta) -> Self {
+        match value {
+            Meta::Path(meta) => Self::Path(meta),
+            Meta::List(meta) => Self::List(meta),
+            Meta::NameValue(meta) => Self::NameValue(meta),
+        }
+    }
+}
+
+impl Parse for CustomMeta {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(if input.peek(Token![!]) {
+            Self::Not(input.parse()?, input.parse()?)
+        } else {
+            Meta::parse(input)?.into()
+        })
+    }
+}
+
+impl CustomMeta {
+    pub fn path(&self) -> &Path {
+        match self {
+            CustomMeta::Not(_not, path) => path,
+            CustomMeta::Path(path) => path,
+            CustomMeta::List(meta) => &meta.path,
+            CustomMeta::NameValue(meta) => &meta.path,
+        }
+    }
+}

--- a/schemars_derive/src/attr/parse_meta.rs
+++ b/schemars_derive/src/attr/parse_meta.rs
@@ -2,48 +2,38 @@ use proc_macro2::{TokenStream, TokenTree};
 use syn::{
     parse::{Parse, ParseStream, Parser},
     punctuated::Punctuated,
-    Expr, ExprLit, Lit, LitStr, Meta, MetaList, MetaNameValue,
+    spanned::Spanned,
+    Expr, ExprLit, Lit, LitStr, MetaNameValue,
 };
 
-use super::{path_str, AttrCtxt};
+use super::{path_str, AttrCtxt, CustomMeta};
 
-pub fn require_path_only(meta: Meta, cx: &AttrCtxt) -> Result<(), ()> {
-    match meta {
-        Meta::Path(_) => Ok(()),
-        Meta::List(MetaList {
-            path, delimiter, ..
-        }) => {
-            let name = path_str(&path);
-            cx.syn_error(syn::Error::new(
-                delimiter.span().join(),
-                format_args!(
-                    "unexpected value of {} {} attribute item",
-                    cx.attr_type, name
-                ),
-            ));
-            Err(())
+pub fn require_path_only(meta: CustomMeta, cx: &AttrCtxt) -> Result<(), ()> {
+    let error_span = match &meta {
+        CustomMeta::Path(_) => return Ok(()),
+        CustomMeta::List(meta) => meta.delimiter.span().join(),
+        CustomMeta::NameValue(meta) => {
+            let eq_span = meta.eq_token.span();
+            eq_span.join(meta.value.span()).unwrap_or(eq_span)
         }
-        Meta::NameValue(MetaNameValue {
-            path,
-            eq_token,
-            value,
-        }) => {
-            let name = path_str(&path);
-            cx.error_spanned_by(
-                quote!(#eq_token #value),
-                format_args!(
-                    "unexpected value of {} {} attribute item",
-                    cx.attr_type, name
-                ),
-            );
-            Err(())
-        }
-    }
+        CustomMeta::Not(..) => meta.span(),
+    };
+
+    let name = path_str(meta.path());
+    cx.syn_error(syn::Error::new(
+        error_span,
+        format_args!(
+            "unexpected value of {} {} attribute item",
+            cx.attr_type, name
+        ),
+    ));
+
+    Err(())
 }
 
-pub fn parse_name_value_expr(meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_name_value_expr(meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     match meta {
-        Meta::NameValue(m) => Ok(m.value),
+        CustomMeta::NameValue(m) => Ok(m.value),
         _ => {
             let name = path_str(meta.path());
             cx.error_spanned_by(
@@ -58,30 +48,31 @@ pub fn parse_name_value_expr(meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
     }
 }
 
-pub fn require_name_value_lit_str(meta: Meta, cx: &AttrCtxt) -> Result<LitStr, ()> {
-    let Meta::NameValue(MetaNameValue {
-        value: Expr::Lit(ExprLit {
-            lit: Lit::Str(lit_str),
+pub fn require_name_value_lit_str(meta: CustomMeta, cx: &AttrCtxt) -> Result<LitStr, ()> {
+    match meta {
+        CustomMeta::NameValue(MetaNameValue {
+            value:
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }),
             ..
-        }),
-        ..
-    }) = meta
-    else {
-        let name = path_str(meta.path());
-        cx.error_spanned_by(
-            meta,
-            format_args!(
-                "expected {} {} attribute item to have a string value: `{} = \"...\"`",
-                cx.attr_type, name, name
-            ),
-        );
-        return Err(());
-    };
-
-    Ok(lit_str)
+        }) => Ok(lit_str),
+        _ => {
+            let name = path_str(meta.path());
+            cx.error_spanned_by(
+                meta,
+                format_args!(
+                    "expected {} {} attribute item to have a string value: `{} = \"...\"`",
+                    cx.attr_type, name, name
+                ),
+            );
+            Err(())
+        }
+    }
 }
 
-pub fn parse_name_value_lit_str<T: Parse>(meta: Meta, cx: &AttrCtxt) -> Result<T, ()> {
+pub fn parse_name_value_lit_str<T: Parse>(meta: CustomMeta, cx: &AttrCtxt) -> Result<T, ()> {
     let lit_str = require_name_value_lit_str(meta, cx)?;
 
     parse_lit_str(lit_str, cx)
@@ -105,14 +96,14 @@ fn parse_lit_str<T: Parse>(lit_str: LitStr, cx: &AttrCtxt) -> Result<T, ()> {
 }
 
 pub fn parse_extensions(
-    meta: Meta,
+    meta: CustomMeta,
     cx: &AttrCtxt,
 ) -> Result<impl IntoIterator<Item = Extension>, ()> {
     let parser = Punctuated::<Extension, Token![,]>::parse_terminated;
     parse_meta_list_with(&meta, cx, parser)
 }
 
-pub fn parse_length_or_range(outer_meta: Meta, cx: &AttrCtxt) -> Result<LengthOrRange, ()> {
+pub fn parse_length_or_range(outer_meta: CustomMeta, cx: &AttrCtxt) -> Result<LengthOrRange, ()> {
     let outer_name = path_str(outer_meta.path());
     let mut result = LengthOrRange::default();
 
@@ -150,11 +141,11 @@ pub fn parse_length_or_range(outer_meta: Meta, cx: &AttrCtxt) -> Result<LengthOr
     Ok(result)
 }
 
-pub fn parse_pattern(meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_pattern(meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     parse_meta_list_with(&meta, cx, Expr::parse)
 }
 
-pub fn parse_schemars_regex(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_schemars_regex(outer_meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     let mut pattern = None;
 
     for nested_meta in parse_nested_meta(outer_meta.clone(), cx)? {
@@ -183,7 +174,7 @@ pub fn parse_schemars_regex(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()>
     })
 }
 
-pub fn parse_validate_regex(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_validate_regex(outer_meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     let mut path = None;
 
     for nested_meta in parse_nested_meta(outer_meta.clone(), cx)? {
@@ -209,9 +200,9 @@ pub fn parse_validate_regex(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()>
     })
 }
 
-pub fn parse_contains(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_contains(outer_meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     enum ContainsFormat {
-        Metas(Punctuated<Meta, Token![,]>),
+        Metas(Punctuated<CustomMeta, Token![,]>),
         Expr(Expr),
     }
 
@@ -222,8 +213,8 @@ pub fn parse_contains(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
             // This heuristic may not generalise well-enough for attributes other than `contains`!
             // `foo = bar` => Metas (not Expr::Assign)
             // `foo, bar`  => Metas
-            // `foo`       => Expr (not Meta::Path)
-            // `foo(bar)`  => Expr (not Meta::List)
+            // `foo`       => Expr (not CustomMeta::Path)
+            // `foo(bar)`  => Expr (not CustomMeta::List)
             if input.peek2(Token![,]) || input.peek2(Token![=]) {
                 Punctuated::parse_terminated(input).map(Self::Metas)
             } else {
@@ -274,13 +265,20 @@ pub fn parse_contains(outer_meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
     })
 }
 
-pub fn parse_nested_meta(meta: Meta, cx: &AttrCtxt) -> Result<impl IntoIterator<Item = Meta>, ()> {
-    let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+pub fn parse_nested_meta(
+    meta: CustomMeta,
+    cx: &AttrCtxt,
+) -> Result<impl IntoIterator<Item = CustomMeta>, ()> {
+    let parser = Punctuated::<CustomMeta, Token![,]>::parse_terminated;
     parse_meta_list_with(&meta, cx, parser)
 }
 
-fn parse_meta_list_with<F: Parser>(meta: &Meta, cx: &AttrCtxt, parser: F) -> Result<F::Output, ()> {
-    let Meta::List(meta_list) = meta else {
+fn parse_meta_list_with<F: Parser>(
+    meta: &CustomMeta,
+    cx: &AttrCtxt,
+    parser: F,
+) -> Result<F::Output, ()> {
+    let CustomMeta::List(meta_list) = meta else {
         let name = path_str(meta.path());
         cx.error_spanned_by(
             meta,
@@ -298,7 +296,7 @@ fn parse_meta_list_with<F: Parser>(meta: &Meta, cx: &AttrCtxt, parser: F) -> Res
 }
 
 // Like `parse_name_value_expr`, but if the result is a string literal, then parse its contents.
-pub fn parse_name_value_expr_handle_lit_str(meta: Meta, cx: &AttrCtxt) -> Result<Expr, ()> {
+pub fn parse_name_value_expr_handle_lit_str(meta: CustomMeta, cx: &AttrCtxt) -> Result<Expr, ()> {
     let expr = parse_name_value_expr(meta, cx)?;
 
     if let Expr::Lit(ExprLit {

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -1,7 +1,7 @@
 use quote::ToTokens;
 use serde_derive_internals::Ctxt;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 use syn::parse::Parser;
 use syn::{Attribute, Data, Field, Variant};
 
@@ -79,9 +79,9 @@ fn process_attrs(ctxt: &Ctxt, attrs: &mut Vec<Attribute>) {
     *attrs = other_attrs;
 
     let mut effective_serde_meta = Vec::new();
-    let mut unset_meta = HashMap::new();
-    let mut serde_meta_names = HashSet::new();
-    let mut schemars_meta_names = HashSet::new();
+    let mut unset_meta = BTreeMap::new();
+    let mut serde_meta_names = BTreeSet::new();
+    let mut schemars_meta_names = BTreeSet::new();
 
     // Copy appropriate #[schemars(...)] attributes to #[serde(...)] attributes
     for meta in get_meta_items(attrs, "schemars", ctxt) {

--- a/schemars_derive/src/attr/schemars_to_serde.rs
+++ b/schemars_derive/src/attr/schemars_to_serde.rs
@@ -2,9 +2,9 @@ use quote::ToTokens;
 use serde_derive_internals::Ctxt;
 use std::collections::HashSet;
 use syn::parse::Parser;
-use syn::{Attribute, Data, Field, Meta, Variant};
+use syn::{Attribute, Data, Field, Variant};
 
-use super::get_meta_items;
+use super::{get_meta_items, CustomMeta};
 
 // List of keywords that can appear in #[serde(...)]/#[schemars(...)] attributes which we want
 // serde_derive_internals to parse for us.
@@ -129,7 +129,7 @@ fn to_tokens(attrs: &[Attribute]) -> impl ToTokens {
     tokens
 }
 
-fn get_meta_ident(meta: &Meta) -> Option<String> {
+fn get_meta_ident(meta: &CustomMeta) -> Option<String> {
     meta.path().get_ident().map(|i| i.to_string())
 }
 

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+// TODO make clippy pedantic
+#![allow(clippy::result_large_err)]
 
 #[macro_use]
 extern crate quote;


### PR DESCRIPTION
Addresses #433 (and #172)