### PR TITLE
Add `_unstable_ref_variants` attribute

### DIFF
--- a/schemars/tests/integration/enums_ref_variants.rs
+++ b/schemars/tests/integration/enums_ref_variants.rs
@@ -1,0 +1,326 @@
+use crate::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+struct UnitStruct;
+
+#[derive(JsonSchema, Deserialize, Serialize, Default)]
+struct Struct {
+    foo: i32,
+    bar: bool,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[schemars(_unstable_ref_variants)]
+enum External {
+    UnitOne,
+    StringMap(BTreeMap<String, String>),
+    UnitStructNewType(UnitStruct),
+    StructNewType(Struct),
+    Struct {
+        foo: i32,
+        bar: bool,
+    },
+    Tuple(i32, bool),
+    UnitTwo,
+    #[serde(with = "unit_variant_as_u64")]
+    #[schemars(with = "u64")]
+    UnitAsInt,
+    #[serde(with = "tuple_variant_as_str")]
+    #[schemars(schema_with = "tuple_variant_as_str::json_schema")]
+    TupleAsStr(i32, bool),
+}
+
+impl External {
+    fn values() -> impl IntoIterator<Item = Self> {
+        [
+            Self::UnitOne,
+            Self::StringMap(
+                [("hello".to_owned(), "world".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
+            Self::UnitStructNewType(UnitStruct),
+            Self::StructNewType(Struct {
+                foo: 123,
+                bar: true,
+            }),
+            Self::Struct {
+                foo: 123,
+                bar: true,
+            },
+            Self::Tuple(456, false),
+            Self::UnitTwo,
+            Self::UnitAsInt,
+            Self::TupleAsStr(789, true),
+        ]
+    }
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+#[serde(tag = "tag")]
+#[schemars(_unstable_ref_variants)]
+enum Internal {
+    UnitOne,
+    StringMap(BTreeMap<String, String>),
+    UnitStructNewType(UnitStruct),
+    StructNewType(Struct),
+    Struct { foo: i32, bar: bool },
+    // Internally-tagged enums don't support tuple variants
+    //  Tuple(i32, bool),
+    UnitTwo,
+    // Internally-tagged enum variants don't support non-object "payloads"
+    //  #[serde(with = "unit_variant_as_u64")]
+    //  #[schemars(with = "u64")]
+    //  UnitAsInt,
+    // Internally-tagged enums don't support tuple variants
+    //  #[serde(with = "tuple_variant_as_str")]
+    //  #[schemars(schema_with = "tuple_variant_as_str::json_schema")]
+    //  TupleAsStr(i32, bool),
+}
+
+impl Internal {
+    fn values() -> impl IntoIterator<Item = Self> {
+        [
+            Self::UnitOne,
+            Self::StringMap(
+                [("hello".to_owned(), "world".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
+            Self::UnitStructNewType(UnitStruct),
+            Self::StructNewType(Struct {
+                foo: 123,
+                bar: true,
+            }),
+            Self::Struct {
+                foo: 123,
+                bar: true,
+            },
+            // Self::Tuple(456, false),
+            Self::UnitTwo,
+            // Self::UnitAsInt,
+            // Self::TupleAsStr(789, true),
+        ]
+    }
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+#[serde(tag = "tag", content = "content")]
+#[schemars(_unstable_ref_variants)]
+enum Adjacent {
+    UnitOne,
+    StringMap(BTreeMap<String, String>),
+    UnitStructNewType(UnitStruct),
+    StructNewType(Struct),
+    Struct {
+        foo: i32,
+        bar: bool,
+    },
+    Tuple(i32, bool),
+    UnitTwo,
+    #[serde(with = "unit_variant_as_u64")]
+    #[schemars(with = "u64")]
+    UnitAsInt,
+    #[serde(with = "tuple_variant_as_str")]
+    #[schemars(schema_with = "tuple_variant_as_str::json_schema")]
+    TupleAsStr(i32, bool),
+}
+
+impl Adjacent {
+    fn values() -> impl IntoIterator<Item = Self> {
+        [
+            Self::UnitOne,
+            Self::StringMap(
+                [("hello".to_owned(), "world".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
+            Self::UnitStructNewType(UnitStruct),
+            Self::StructNewType(Struct {
+                foo: 123,
+                bar: true,
+            }),
+            Self::Struct {
+                foo: 123,
+                bar: true,
+            },
+            Self::Tuple(456, false),
+            Self::UnitTwo,
+            Self::UnitAsInt,
+            Self::TupleAsStr(789, true),
+        ]
+    }
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+#[serde(untagged)]
+#[schemars(_unstable_ref_variants)]
+enum Untagged {
+    UnitOne,
+    StringMap(BTreeMap<String, String>),
+    UnitStructNewType(UnitStruct),
+    StructNewType(Struct),
+    Struct {
+        foo: i32,
+        bar: bool,
+    },
+    Tuple(i32, bool),
+    UnitTwo,
+    #[serde(with = "unit_variant_as_u64")]
+    #[schemars(with = "u64")]
+    UnitAsInt,
+    #[serde(with = "tuple_variant_as_str")]
+    #[schemars(schema_with = "tuple_variant_as_str::json_schema")]
+    TupleAsStr(i32, bool),
+}
+
+impl Untagged {
+    fn values() -> impl IntoIterator<Item = Self> {
+        [
+            Self::UnitOne,
+            Self::StringMap(
+                [("hello".to_owned(), "world".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
+            Self::UnitStructNewType(UnitStruct),
+            Self::StructNewType(Struct {
+                foo: 123,
+                bar: true,
+            }),
+            Self::Struct {
+                foo: 123,
+                bar: true,
+            },
+            Self::Tuple(456, false),
+            Self::UnitTwo,
+            Self::UnitAsInt,
+            Self::TupleAsStr(789, true),
+        ]
+    }
+}
+
+mod unit_variant_as_u64 {
+    pub(super) fn serialize<S>(ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ser.serialize_u64(42)
+    }
+
+    pub(super) fn deserialize<'de, D>(deser: D) -> Result<(), D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Deserialize;
+
+        u64::deserialize(deser).map(|_| ())
+    }
+}
+
+mod tuple_variant_as_str {
+    pub(super) fn serialize<S>(i: &i32, b: &bool, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ser.collect_str(&format_args!("{i} {b}"))
+    }
+
+    pub(super) fn deserialize<'de, D>(deser: D) -> Result<(i32, bool), D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{Deserialize, Error};
+        let error = || Error::custom("invalid string");
+
+        let (i, b) = <&str>::deserialize(deser)?
+            .split_once(' ')
+            .ok_or_else(error)?;
+
+        Ok((
+            i.parse().map_err(|_| error())?,
+            b.parse().map_err(|_| error())?,
+        ))
+    }
+
+    pub(super) fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "pattern": r"^\d+ (true|false)$"
+        })
+    }
+}
+
+#[test]
+fn externally_tagged_enum() {
+    test!(External)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip(External::values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn internally_tagged_enum() {
+    test!(Internal)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip(Internal::values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn adjacently_tagged_enum() {
+    test!(Adjacent)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip(Adjacent::values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn untagged_enum() {
+    test!(Untagged)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip(Untagged::values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[derive(JsonSchema, Serialize, Deserialize)]
+#[schemars(_unstable_ref_variants)]
+enum NoVariants {}
+
+#[test]
+fn no_variants() {
+    test!(NoVariants)
+        .assert_snapshot()
+        .assert_rejects_de(arbitrary_values());
+}
+
+#[derive(JsonSchema, Serialize, Deserialize)]
+#[serde(rename_all_fields = "UPPERCASE", rename_all = "snake_case")]
+#[schemars(_unstable_ref_variants)]
+enum Renamed {
+    StructVariant {
+        field: String,
+    },
+    #[serde(rename = "custom name variant")]
+    RenamedStructVariant {
+        #[serde(rename = "custom name field")]
+        field: String,
+    },
+}
+
+#[test]
+fn renamed() {
+    test!(Renamed)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([
+            Renamed::StructVariant {
+                field: "foo".to_owned(),
+            },
+            Renamed::RenamedStructVariant {
+                field: "bar".to_owned(),
+            },
+        ])
+        .assert_rejects_de(arbitrary_values());
+}

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod enum_repr;
 mod enums;
 mod enums_deny_unknown_fields;
 mod enums_flattened;
+mod enums_ref_variants;
 mod enums_untagged_variant;
 mod examples;
 mod extend;

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~adjacently_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~adjacently_tagged_enum.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Adjacent",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/UnitOne"
+    },
+    {
+      "$ref": "#/$defs/StringMap"
+    },
+    {
+      "$ref": "#/$defs/UnitStructNewType"
+    },
+    {
+      "$ref": "#/$defs/StructNewType"
+    },
+    {
+      "$ref": "#/$defs/Struct2"
+    },
+    {
+      "$ref": "#/$defs/Tuple"
+    },
+    {
+      "$ref": "#/$defs/UnitTwo"
+    },
+    {
+      "$ref": "#/$defs/UnitAsInt"
+    },
+    {
+      "$ref": "#/$defs/TupleAsStr"
+    }
+  ],
+  "$defs": {
+    "UnitOne": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitOne"
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "StringMap": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "StringMap"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "UnitStructNewType": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitStructNewType"
+        },
+        "content": {
+          "$ref": "#/$defs/UnitStruct"
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "UnitStruct": {
+      "type": "null"
+    },
+    "StructNewType": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "StructNewType"
+        },
+        "content": {
+          "$ref": "#/$defs/Struct"
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    },
+    "Struct2": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "Struct"
+        },
+        "content": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bar": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "foo",
+            "bar"
+          ]
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "Tuple": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "Tuple"
+        },
+        "content": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "int32"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "UnitTwo": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitTwo"
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "UnitAsInt": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitAsInt"
+        },
+        "content": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    },
+    "TupleAsStr": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "TupleAsStr"
+        },
+        "content": {
+          "type": "string",
+          "pattern": "^\\d+ (true|false)$"
+        }
+      },
+      "required": [
+        "tag",
+        "content"
+      ]
+    }
+  }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~externally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~externally_tagged_enum.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "External",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/unitOne"
+    },
+    {
+      "$ref": "#/$defs/stringMap"
+    },
+    {
+      "$ref": "#/$defs/unitStructNewType"
+    },
+    {
+      "$ref": "#/$defs/structNewType"
+    },
+    {
+      "$ref": "#/$defs/struct"
+    },
+    {
+      "$ref": "#/$defs/tuple"
+    },
+    {
+      "$ref": "#/$defs/unitTwo"
+    },
+    {
+      "$ref": "#/$defs/unitAsInt"
+    },
+    {
+      "$ref": "#/$defs/tupleAsStr"
+    }
+  ],
+  "$defs": {
+    "unitOne": {
+      "type": "string",
+      "const": "unitOne"
+    },
+    "stringMap": {
+      "type": "object",
+      "properties": {
+        "stringMap": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "stringMap"
+      ],
+      "additionalProperties": false
+    },
+    "unitStructNewType": {
+      "type": "object",
+      "properties": {
+        "unitStructNewType": {
+          "$ref": "#/$defs/UnitStruct"
+        }
+      },
+      "required": [
+        "unitStructNewType"
+      ],
+      "additionalProperties": false
+    },
+    "UnitStruct": {
+      "type": "null"
+    },
+    "structNewType": {
+      "type": "object",
+      "properties": {
+        "structNewType": {
+          "$ref": "#/$defs/Struct"
+        }
+      },
+      "required": [
+        "structNewType"
+      ],
+      "additionalProperties": false
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    },
+    "struct": {
+      "type": "object",
+      "properties": {
+        "struct": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bar": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "foo",
+            "bar"
+          ]
+        }
+      },
+      "required": [
+        "struct"
+      ],
+      "additionalProperties": false
+    },
+    "tuple": {
+      "type": "object",
+      "properties": {
+        "tuple": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "int32"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "required": [
+        "tuple"
+      ],
+      "additionalProperties": false
+    },
+    "unitTwo": {
+      "type": "string",
+      "const": "unitTwo"
+    },
+    "unitAsInt": {
+      "type": "object",
+      "properties": {
+        "unitAsInt": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "unitAsInt"
+      ],
+      "additionalProperties": false
+    },
+    "tupleAsStr": {
+      "type": "object",
+      "properties": {
+        "tupleAsStr": {
+          "type": "string",
+          "pattern": "^\\d+ (true|false)$"
+        }
+      },
+      "required": [
+        "tupleAsStr"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~internally_tagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~internally_tagged_enum.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Internal",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/UnitOne"
+    },
+    {
+      "$ref": "#/$defs/StringMap"
+    },
+    {
+      "$ref": "#/$defs/UnitStructNewType"
+    },
+    {
+      "$ref": "#/$defs/StructNewType"
+    },
+    {
+      "$ref": "#/$defs/Struct2"
+    },
+    {
+      "$ref": "#/$defs/UnitTwo"
+    }
+  ],
+  "$defs": {
+    "UnitOne": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitOne"
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "StringMap": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "StringMap"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "UnitStructNewType": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitStructNewType"
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "StructNewType": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "StructNewType"
+        }
+      },
+      "$ref": "#/$defs/Struct",
+      "required": [
+        "tag"
+      ]
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    },
+    "Struct2": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        },
+        "tag": {
+          "type": "string",
+          "const": "Struct"
+        }
+      },
+      "required": [
+        "tag",
+        "foo",
+        "bar"
+      ]
+    },
+    "UnitTwo": {
+      "type": "object",
+      "properties": {
+        "tag": {
+          "type": "string",
+          "const": "UnitTwo"
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    }
+  }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~no_variants.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~no_variants.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NoVariants",
+  "not": {}
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~renamed.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~renamed.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Renamed",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/struct_variant"
+    },
+    {
+      "$ref": "#/$defs/custom%20name%20variant"
+    }
+  ],
+  "$defs": {
+    "struct_variant": {
+      "type": "object",
+      "properties": {
+        "struct_variant": {
+          "type": "object",
+          "properties": {
+            "FIELD": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "FIELD"
+          ]
+        }
+      },
+      "required": [
+        "struct_variant"
+      ],
+      "additionalProperties": false
+    },
+    "custom name variant": {
+      "type": "object",
+      "properties": {
+        "custom name variant": {
+          "type": "object",
+          "properties": {
+            "custom name field": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "custom name field"
+          ]
+        }
+      },
+      "required": [
+        "custom name variant"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~untagged_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums_ref_variants.rs~untagged_enum.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Untagged",
+  "anyOf": [
+    {
+      "$ref": "#/$defs/UnitOne"
+    },
+    {
+      "$ref": "#/$defs/StringMap"
+    },
+    {
+      "$ref": "#/$defs/UnitStructNewType"
+    },
+    {
+      "$ref": "#/$defs/StructNewType"
+    },
+    {
+      "$ref": "#/$defs/Struct2"
+    },
+    {
+      "$ref": "#/$defs/Tuple"
+    },
+    {
+      "$ref": "#/$defs/UnitTwo"
+    },
+    {
+      "$ref": "#/$defs/UnitAsInt"
+    },
+    {
+      "$ref": "#/$defs/TupleAsStr"
+    }
+  ],
+  "$defs": {
+    "UnitOne": {
+      "type": "null"
+    },
+    "StringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "UnitStructNewType": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "UnitStruct": {
+      "type": "null"
+    },
+    "StructNewType": {
+      "$ref": "#/$defs/Struct"
+    },
+    "Struct": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    },
+    "Struct2": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "bar": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ]
+    },
+    "Tuple": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "type": "boolean"
+        }
+      ],
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "UnitTwo": {
+      "type": "null"
+    },
+    "UnitAsInt": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    "TupleAsStr": {
+      "type": "string",
+      "pattern": "^\\d+ (true|false)$"
+    }
+  }
+}

--- a/schemars_derive/src/ast/from_serde.rs
+++ b/schemars_derive/src/ast/from_serde.rs
@@ -20,7 +20,7 @@ impl<'a> FromSerde for Container<'a> {
 
     fn from_serde(errors: &Ctxt, serde: Self::SerdeType) -> Self {
         let data = Data::from_serde(errors, serde.data);
-        let attrs = ContainerAttrs::new(&serde.original.attrs, errors);
+        let attrs = ContainerAttrs::new(&serde.original.attrs, &data, errors);
         let rename_type_params = match &attrs.rename_format_string {
             Some(s) => crate::name::get_rename_format_type_params(errors, s, serde.generics),
             None => BTreeSet::new(),


### PR DESCRIPTION
Addresses #39 #157 #201 #390

It's "unstable" until I get some feedback about whether this solves the problem correctly. Some things that need deciding (some of these can be implemented after stabilisation if necessary):
- Naming - is `ref_variants` clear enough?
- Should trivial unit variants be inlined regardless of this attribute? (currently, they're not)
- Allow individual variants to opt in to being `$ref`'d, instead of the entire enum?
- Allow individual variants to opt back in to being inlined when the enum has this attribute?
- Currently, the variant name is used as the schema name - should the enum's name be prepended to this? Should it be configurable?