### PR TITLE
Fix deriving with `no_std`

### DIFF
--- a/schemars/tests/no_std.rs
+++ b/schemars/tests/no_std.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+use schemars::{schema_for, JsonSchema};
+
+#[derive(JsonSchema, Default)]
+pub struct MyStruct {
+    /// A number
+    pub my_int: i32,
+    #[schemars(extend("x-test" = {"k": "v"}))]
+    pub my_bool: bool,
+    pub my_nullable_enum: Option<MyEnum>,
+}
+
+#[derive(JsonSchema)]
+pub enum MyEnum {
+    StringNewType(&'static str),
+    StructVariant { floats: &'static [f32] },
+}
+
+#[test]
+fn test_no_std() {
+    let _schema = schema_for!(MyStruct);
+}

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -113,12 +113,12 @@ impl Field<'_> {
 
         if self.serde_attrs.skip_deserializing() {
             mutators.push(quote! {
-                #SCHEMA.insert("readOnly".to_owned(), true.into());
+                #SCHEMA.insert("readOnly".into(), true.into());
             });
         }
         if self.serde_attrs.skip_serializing() {
             mutators.push(quote! {
-                #SCHEMA.insert("writeOnly".to_owned(), true.into());
+                #SCHEMA.insert("writeOnly".into(), true.into());
             });
         }
     }

--- a/schemars_derive/src/attr/mod.rs
+++ b/schemars_derive/src/attr/mod.rs
@@ -204,7 +204,7 @@ impl CommonAttrs {
 
         if self.deprecated {
             mutators.push(quote! {
-                #SCHEMA.insert("deprecated".to_owned(), true.into());
+                #SCHEMA.insert("deprecated".into(), true.into());
             });
         }
 
@@ -215,13 +215,13 @@ impl CommonAttrs {
                 }
             });
             mutators.push(quote! {
-                #SCHEMA.insert("examples".to_owned(), schemars::_private::serde_json::Value::Array([#(#examples),*].into_iter().flatten().collect()));
+                #SCHEMA.insert("examples".into(), schemars::_private::serde_json::Value::Array([#(#examples),*].into_iter().flatten().collect()));
             });
         }
 
         for (k, v) in &self.extensions {
             mutators.push(quote! {
-                #SCHEMA.insert(#k.to_owned(), schemars::_private::serde_json::json!(#v));
+                #SCHEMA.insert(#k.into(), schemars::_private::serde_json::json!(#v));
             });
         }
 

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -587,7 +587,7 @@ fn expr_for_untagged_enum_variant(
             let title = variant.name();
             schema_expr.mutators.push(quote! {
                 if #GENERATOR.settings().untagged_enum_variant_titles {
-                    #SCHEMA.insert("title".to_owned(), #title.into());
+                    #SCHEMA.insert("title".into(), #title.into());
                 }
             });
         }
@@ -701,7 +701,7 @@ fn expr_for_struct(
                 if let Some(default) = field_default_expr(field, set_container_default.is_some()) {
                     schema_expr.mutators.push(quote! {
                         #default.and_then(|d| schemars::_schemars_maybe_to_value!(d))
-                            .map(|d| #SCHEMA.insert("default".to_owned(), d));
+                            .map(|d| #SCHEMA.insert("default".into(), d));
                     });
                 }
 


### PR DESCRIPTION
Fixes #441

With `no_std`, the `std` prelude is not used, so `ToOwned` is not imported, causing:
```
error[E0599]: no method named `to_owned` found for reference `&'static str` in the current scope
...
help: items from traits can only be used if the trait is in scope
help: trait `ToOwned` which provides `to_owned` is implemented but not in scope; perhaps you want to import it
```

This commit works-around it by using `into()`, since `Into` is included in the `core` prelude (which is available even in `no_std`)