### PR TITLE
Improve handling of property ordering in schema serialization

### DIFF
--- a/schemars/tests/integration/snapshots/schemars/tests/integration/structs.rs~property_order.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/structs.rs~property_order.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PropertyOrder",
+  "type": "object",
+  "properties": {
+    "$defs": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "examples": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "properties": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "required": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "$schema": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "title": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "type": {
+      "$ref": "#/$defs/UnitStruct"
+    },
+    "x-custom": {
+      "$ref": "#/$defs/UnitStruct"
+    }
+  },
+  "required": [
+    "$defs",
+    "examples",
+    "properties",
+    "required",
+    "$schema",
+    "title",
+    "type",
+    "x-custom"
+  ],
+  "examples": [
+    {
+      "$defs": null,
+      "examples": null,
+      "properties": null,
+      "required": null,
+      "$schema": null,
+      "title": null,
+      "type": null,
+      "x-custom": null
+    }
+  ],
+  "x-custom": {
+    "$defs": null,
+    "examples": null,
+    "properties": null,
+    "required": null,
+    "$schema": null,
+    "title": null,
+    "type": null,
+    "x-custom": null
+  },
+  "$defs": {
+    "UnitStruct": {
+      "type": "null"
+    }
+  }
+}

--- a/schemars/tests/integration/structs.rs
+++ b/schemars/tests/integration/structs.rs
@@ -87,3 +87,66 @@ fn deny_unknown_fields() {
         })])
         .assert_matches_de_roundtrip(arbitrary_values());
 }
+
+#[derive(JsonSchema, Deserialize, Serialize, Default)]
+#[schemars(example = PropertyOrder::default(), extend("x-custom" = PropertyOrder::default()))]
+struct PropertyOrder {
+    #[serde(rename = "$defs")]
+    pub defs: UnitStruct,
+    pub examples: UnitStruct,
+    pub properties: UnitStruct,
+    pub required: UnitStruct,
+    #[serde(rename = "$schema")]
+    pub schema: UnitStruct,
+    pub title: UnitStruct,
+    pub r#type: UnitStruct,
+    #[serde(rename = "x-custom")]
+    pub x_custom: UnitStruct,
+}
+
+#[cfg_attr(not(feature = "preserve_order"), ignore)]
+#[test]
+fn property_order() {
+    test!(PropertyOrder).assert_snapshot().custom(|schema, _| {
+        fn get_property_keys(value: &Value) -> Vec<&str> {
+            value
+                .as_object()
+                .expect("expected value to be an object")
+                .keys()
+                .map(String::as_str)
+                .collect()
+        }
+
+        let value = serde_json::to_value(schema).unwrap();
+
+        assert!(matches!(
+            get_property_keys(&value).as_slice(),
+            // order of `examples`, `required` and `x-custom` is unspecified
+            &["$schema", "title", "type", "properties", .., "$defs"]
+        ));
+
+        let field_order = &[
+            "$defs",
+            "examples",
+            "properties",
+            "required",
+            "$schema",
+            "title",
+            "type",
+            "x-custom",
+        ];
+
+        assert_eq!(
+            get_property_keys(&value["properties"]).as_slice(),
+            field_order,
+        );
+        assert_eq!(
+            get_property_keys(&value["examples"][0]).as_slice(),
+            field_order,
+        );
+        assert_eq!(
+            get_property_keys(&value["x-custom"]).as_slice(),
+            field_order,
+        );
+    });
+}


### PR DESCRIPTION
Fixes #444

Previously, all objects within schemas were effectively assumed to be schemas themselves, so some of their properties were reordered on serialization to make them more human-readable (e.g. by putting `$id`/`$schema`/`title` at the start). Unfortunately, this also causes properties of non-schemas objects to be reordered - e.g. the value of a `properties` property.

This PR better handles objects that are not schemas by not reordering their properties, but still reordering the (inner) properties of the values of those (outer) properties, when those values are expected to be schemas themselves. I know, it's confusing...