### PR TITLE
Improve `json_schema!`-macro compability with older rust editions

### DIFF
--- a/schemars/src/macros.rs
+++ b/schemars/src/macros.rs
@@ -102,7 +102,7 @@ macro_rules! json_schema {
     (
         {$($json_object:tt)*}
     ) => {
-        $crate::Schema::try_from($crate::_private::serde_json::json!({$($json_object)*})).unwrap()
+        <$crate::Schema as ::core::convert::TryFrom<_>>::try_from($crate::_private::serde_json::json!({$($json_object)*})).unwrap()
     };
     (true) => {
         $crate::Schema::from(true)


### PR DESCRIPTION
`TryFrom` is only available in the prelude for Rust 2021+