### PR TITLE
feat: add feature for arcstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +984,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "schemars"
 version = "1.0.3"
 dependencies = [
+ "arcstr",
  "arrayvec",
  "bigdecimal",
  "bytes",

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -31,6 +31,7 @@ rust_decimal1 = { version = "1", default-features = false, optional = true, pack
 semver1 = { version = "1.0.9", default-features = false, optional = true, package = "semver" }
 smallvec1 = { version = "1.0", default-features = false, optional = true, package = "smallvec" }
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
+arcstr1 = { version = "1.2.0", default-features = false, optional = true, package = "arcstr" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
 
@@ -56,6 +57,7 @@ rust_decimal1 = { version = "1", default-features = false, features = ["serde"],
 semver1 = { version = "1.0.9", default-features = false, features = ["serde"], package = "semver" }
 smallvec1 = { version = "1.0", default-features = false, features = ["serde"], package = "smallvec" }
 smol_str02 = { version = "0.2.1", default-features = false, features = ["serde"], package = "smol_str" }
+arcstr1 = { version = "1.2.0", default-features = false, features = ["serde"], package = "arcstr" }
 url2 = { version = "2.0", default-features = false, features = ["serde", "std"], package = "url" }
 uuid1 = { version = "1.0", default-features = false, features = ["serde"], package = "uuid" }
 

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -88,6 +88,9 @@ forward_impl!((<A: smallvec1::Array> crate::JsonSchema for smallvec1::SmallVec<A
 #[cfg(feature = "smol_str02")]
 forward_impl!(smol_str02::SmolStr => alloc::string::String);
 
+#[cfg(feature = "arcstr1")]
+forward_impl!(arcstr1::ArcStr => alloc::string::String);
+
 #[cfg(feature = "url2")]
 mod url2;
 

--- a/schemars/tests/integration/arcstr.rs
+++ b/schemars/tests/integration/arcstr.rs
@@ -1,0 +1,11 @@
+use arcstr1::ArcStr;
+
+use crate::prelude::*;
+
+#[test]
+fn arcstr() {
+    test!(ArcStr)
+        .assert_identical::<String>()
+        .assert_allows_ser_roundtrip(["".into(), "test".into()])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -47,6 +47,8 @@ mod skip;
 mod smallvec;
 #[cfg(feature = "smol_str02")]
 mod smol_str;
+#[cfg(feature = "arcstr1")]
+mod arcstr;
 mod std_types;
 mod structs;
 mod transform;


### PR DESCRIPTION
Today, there is support for smol_str but we use arcstr which makes us unable to use schemars. This adds support for arcstr, mirroring the smol_str support.