### PR TITLE
Fix impls for atomic types in non-nightly

### DIFF
--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -52,7 +52,6 @@ mod std_time;
 mod tuple;
 mod wrapper;
 
-#[cfg(target_has_atomic)]
 mod atomic;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
`#[cfg(target_has_atomic)]` (without a value) is nightly-only

Fixes #453