### PR TITLE
Implement JsonSchema for uuid1 format variants as well

### DIFF
--- a/schemars/src/json_schema_impls/uuid1.rs
+++ b/schemars/src/json_schema_impls/uuid1.rs
@@ -2,22 +2,33 @@ use crate::SchemaGenerator;
 use crate::{json_schema, JsonSchema, Schema};
 use alloc::borrow::Cow;
 use uuid1::Uuid;
+use uuid1::fmt::{Braced, Simple, Hyphenated, Urn};
 
-impl JsonSchema for Uuid {
-    inline_schema!();
+macro_rules! uuid_variant_schema {
+    ($type:ty) => {
+        impl JsonSchema for $type {
+            inline_schema!();
 
-    fn schema_name() -> Cow<'static, str> {
-        "Uuid".into()
-    }
+            fn schema_name() -> Cow<'static, str> {
+                "Uuid".into()
+            }
 
-    fn schema_id() -> Cow<'static, str> {
-        "uuid::Uuid".into()
-    }
+            fn schema_id() -> Cow<'static, str> {
+                "uuid::Uuid".into()
+            }
 
-    fn json_schema(_: &mut SchemaGenerator) -> Schema {
-        json_schema!({
-            "type": "string",
-            "format": "uuid",
-        })
-    }
+            fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                json_schema!({
+                    "type": "string",
+                    "format": "uuid",
+                })
+            }
+        }
+    };
 }
+
+uuid_variant_schema!(Uuid);
+uuid_variant_schema!(Simple);
+uuid_variant_schema!(Braced);
+uuid_variant_schema!(Urn);
+uuid_variant_schema!(Hyphenated);


### PR DESCRIPTION
This is necessary because some libraries, like in my case sea_orm, depend on the use of these formatting variants in their Database Entity structs for proper deserialization of the data coming from sqlx.

I think this is generally a wanted change. Since these types are only wrappers I found it to be appropriate to just use the same definition of schema. But I might be wrong on this, if you think an implementation should be provided per type, let me know and I can update this PR.

Thanks.