### PR TITLE
feat: support `date-time-local`

### DIFF
--- a/schemars/src/json_schema_impls/chrono04.rs
+++ b/schemars/src/json_schema_impls/chrono04.rs
@@ -88,6 +88,6 @@ macro_rules! formatted_string_impl {
 }
 
 formatted_string_impl!(NaiveDate, "date");
-formatted_string_impl!(NaiveDateTime, "partial-date-time");
-formatted_string_impl!(NaiveTime, "partial-time");
+formatted_string_impl!(NaiveDateTime, "date-time-local");
+formatted_string_impl!(NaiveTime, "time-local");
 formatted_string_impl!(DateTime, "date-time", <Tz: TimeZone> JsonSchema for DateTime<Tz>);

--- a/schemars/src/json_schema_impls/jiff02.rs
+++ b/schemars/src/json_schema_impls/jiff02.rs
@@ -34,5 +34,5 @@ formatted_string_impl!(Span, "duration");
 formatted_string_impl!(Timestamp, "date-time");
 formatted_string_impl!(Zoned, "zoned-date-time");
 formatted_string_impl!(Date, "date");
-formatted_string_impl!(Time, "partial-time");
-formatted_string_impl!(DateTime, "partial-date-time");
+formatted_string_impl!(Time, "time-local");
+formatted_string_impl!(DateTime, "date-time-local");

--- a/schemars/tests/integration/chrono.rs
+++ b/schemars/tests/integration/chrono.rs
@@ -37,7 +37,7 @@ fn chrono() {
         // .assert_allows_ser_roundtrip([NaiveDateTime::MIN, NaiveDateTime::MAX])
         .assert_matches_de_roundtrip(arbitrary_values_except(
             Value::is_string,
-            "Custom format 'partial-date-time', so arbitrary strings technically allowed by schema",
+            "Custom format 'date-time-local', so arbitrary strings technically allowed by schema",
         ));
 
     test!(NaiveTime)

--- a/schemars/tests/integration/jiff.rs
+++ b/schemars/tests/integration/jiff.rs
@@ -36,7 +36,7 @@ fn jiff() {
         .assert_allows_ser_roundtrip_default()
         .assert_matches_de_roundtrip(arbitrary_values_except(
             Value::is_string,
-            "Custom format 'partial-date-time', so arbitrary strings technically allowed by schema",
+            "Custom format 'date-time-local', so arbitrary strings technically allowed by schema",
         ));
 
     test!(Time)

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/chrono.rs~chrono.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/chrono.rs~chrono.json
@@ -25,11 +25,11 @@
     },
     "naive_date_time": {
       "type": "string",
-      "format": "partial-date-time"
+      "format": "date-time-local"
     },
     "naive_time": {
       "type": "string",
-      "format": "partial-time"
+      "format": "time-local"
     },
     "time_delta": {
       "type": "array",

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/jiff.rs~jiff.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/jiff.rs~jiff.json
@@ -17,11 +17,11 @@
     },
     "naive_date_time": {
       "type": "string",
-      "format": "partial-date-time"
+      "format": "date-time-local"
     },
     "naive_time": {
       "type": "string",
-      "format": "partial-time"
+      "format": "time-local"
     },
     "duration": {
       "type": "string",


### PR DESCRIPTION
OpenAPI has added [date-time-local](https://spec.openapis.org/registry/format/date-time-local.html) and [time-local](https://spec.openapis.org/registry/format/time-local.html) to the format registry.

