### PR TITLE
Add ijson support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +388,12 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -528,13 +547,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ijson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce2bfde9cd56af9f5d4b8de37d2d203050cfa1f68cb28d5bb163e32389e810e"
+dependencies = [
+ "dashmap",
+ "lazy_static",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -982,6 +1013,7 @@ dependencies = [
  "dyn-clone",
  "either",
  "garde",
+ "ijson",
  "indexmap",
  "jiff",
  "jsonschema",

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -33,6 +33,7 @@ smallvec1 = { version = "1.0", default-features = false, optional = true, packag
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+ijson = {version = "0.1", default-features = false, optional = true}
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/schemars/src/json_schema_impls/ijson.rs
+++ b/schemars/src/json_schema_impls/ijson.rs
@@ -1,0 +1,40 @@
+use crate::SchemaGenerator;
+use crate::_alloc_prelude::*;
+use crate::{json_schema, JsonSchema, Schema};
+use alloc::borrow::Cow;
+use alloc::collections::BTreeMap;
+use ijson::IArray;
+use ijson::INumber;
+use ijson::IObject;
+use ijson::IString;
+use ijson::IValue;
+
+impl JsonSchema for IValue {
+    inline_schema!();
+
+    fn schema_name() -> Cow<'static, str> {
+        "AnyValue".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        true.into()
+    }
+}
+
+forward_impl!(IObject => BTreeMap<String, IValue>);
+forward_impl!(IArray => Vec<IValue>);
+forward_impl!(IString => String);
+
+impl JsonSchema for INumber {
+    inline_schema!();
+
+    fn schema_name() -> Cow<'static, str> {
+        "Number".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "number"
+        })
+    }
+}

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -92,3 +92,6 @@ mod url2;
 
 #[cfg(feature = "uuid1")]
 mod uuid1;
+
+#[cfg(feature = "ijson")]
+mod ijson;


### PR DESCRIPTION
This is based of the `serde_json` implementations.

[`ijson`](https://crates.io/crates/ijson) provides a replacement for `serde_json::Value` which is significantly more memory efficient.

The types map directly onto corresponding json-schema types, so the implementations are fairly trivial.