### PR TITLE
Fix: issue #464 - #[serde(flatten)] on Option<Enum> results in incorrect JsonSchema

### DIFF
--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -54,7 +54,21 @@ pub fn json_schema_for_flatten<T: ?Sized + JsonSchema>(
     let mut schema = T::_schemars_private_non_optional_json_schema(generator);
 
     if T::_schemars_private_is_option() && !required {
-        schema.remove("required");
+        let complex = match schema.try_as_object_mut() {
+            Ok(schema_obj) => contains_immediate_subschema(schema_obj),
+            Err(_) => false,
+        };
+        if complex {
+            schema = json_schema!({
+                "anyOf": [
+                    schema,
+                    //<()>::json_schema(generator)
+                    {}
+                ]
+            });
+        } else {
+            schema.remove("required");
+        }
     }
 
     // Always allow aditional/unevaluated properties, because the outer struct determines

--- a/schemars/tests/integration/enums.rs
+++ b/schemars/tests/integration/enums.rs
@@ -209,6 +209,18 @@ impl Untagged {
     }
 }
 
+#[derive(JsonSchema, Deserialize, Serialize)]
+pub enum FlattenableEnum {
+    A { a: String },
+    B { b: String },
+}
+
+#[derive(JsonSchema, Deserialize, Serialize)]
+pub struct FlattenableOptionalParent {
+    #[serde(flatten)]
+    parent: Option<FlattenableEnum>,
+}
+
 mod unit_variant_as_u64 {
     pub(super) fn serialize<S>(ser: S) -> Result<S::Ok, S::Error>
     where
@@ -387,4 +399,23 @@ fn unit_variants_with_doc_comments() {
                 Some(&("A name I call myself".into())),
             );
         });
+}
+
+#[test]
+fn flatten_optional_enum() {
+    test!(FlattenableOptionalParent)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([
+            FlattenableOptionalParent { parent: None },
+            FlattenableOptionalParent {
+                parent: Some(FlattenableEnum::A {
+                    a: "test1".to_string(),
+                }),
+            },
+            FlattenableOptionalParent {
+                parent: Some(FlattenableEnum::B {
+                    b: "test2".to_string(),
+                }),
+            },
+        ]);
 }

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~flatten_optional_enum.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~flatten_optional_enum.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "A": {
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "a"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "A"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "B": {
+              "properties": {
+                "b": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "b"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "B"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    {}
+  ],
+  "title": "FlattenableOptionalParent",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~optionally_flattening_parent.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/enums.rs~optionally_flattening_parent.json
@@ -1,0 +1,94 @@
+{
+  "$defs": {
+    "Struct": {
+      "properties": {
+        "bar": {
+          "type": "boolean"
+        },
+        "foo": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "foo",
+        "bar"
+      ],
+      "type": "object"
+    },
+    "UnitStruct": {
+      "type": "null"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "anyOf": [
+    {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/UnitStruct"
+        },
+        {
+          "$ref": "#/$defs/Struct"
+        },
+        {
+          "properties": {
+            "bar": {
+              "type": "boolean"
+            },
+            "foo": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "foo",
+            "bar"
+          ],
+          "type": "object"
+        },
+        {
+          "maxItems": 0,
+          "type": "array"
+        },
+        {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "format": "int32",
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "type": "array"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "pattern": "^\\d+ (true|false)$",
+          "type": "string"
+        }
+      ]
+    },
+    {}
+  ],
+  "title": "OptionallyFlatteningParent",
+  "type": "object"
+}


### PR DESCRIPTION
Solution: 
- Wrap flattened optional enum in "anyOf" with original schema and empty object for null cases.
 - Added test cases in enums.rs for this specific problem 