### PR TITLE
feat: add schemas for time crate ^0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +835,12 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pretty_assertions"
@@ -997,6 +1019,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "snapbox",
+ "time",
  "trybuild",
  "url",
  "uuid",
@@ -1194,6 +1217,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `smol_str02` - [smol_str](https://crates.io/crates/smol_str) (^0.2.1)
 - `url2` - [url](https://crates.io/crates/url) (^2.0)
 - `uuid1` - [uuid](https://crates.io/crates/uuid) (^1.0)
+- `time03` - [time](https://crates.io/crates/time) (^0.3)
 
 Bear in mind that each of these feature flags _may_ be removed in a future semver-minor change of Schemars, particularly if a newer semver-incompatible version of the external library has been released for a long time. This is unfortunately necessary to avoid supporting old/unmaintained libraries indefinitely.
 

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -33,6 +33,7 @@ smallvec1 = { version = "1.0", default-features = false, optional = true, packag
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+time03 = { version = "0.3", default-features = false, optional = true, package = "time" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -58,6 +59,7 @@ smallvec1 = { version = "1.0", default-features = false, features = ["serde"], p
 smol_str02 = { version = "0.2.1", default-features = false, features = ["serde"], package = "smol_str" }
 url2 = { version = "2.0", default-features = false, features = ["serde", "std"], package = "url" }
 uuid1 = { version = "1.0", default-features = false, features = ["serde"], package = "uuid" }
+time03 = { version = "0.3", default-features = false, features = ["serde"], package = "time" }
 
 [features]
 default = ["derive", "std"]

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -92,3 +92,6 @@ mod url2;
 
 #[cfg(feature = "uuid1")]
 mod uuid1;
+
+#[cfg(feature = "time03")]
+mod time03;

--- a/schemars/src/json_schema_impls/time03.rs
+++ b/schemars/src/json_schema_impls/time03.rs
@@ -1,0 +1,35 @@
+use crate::SchemaGenerator;
+use crate::{json_schema, JsonSchema, Schema};
+use alloc::borrow::Cow;
+use time03::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+
+macro_rules! formatted_string_impl {
+    ($ty:ident, $format:literal) => {
+        formatted_string_impl!($ty, $format, JsonSchema for $ty);
+    };
+    ($ty:ident, $format:literal, $($desc:tt)+) => {
+        impl $($desc)+ {
+            inline_schema!();
+
+            fn schema_name() -> Cow<'static, str> {
+                stringify!($ty).into()
+            }
+
+            fn schema_id() -> Cow<'static, str>  {
+                stringify!(chrono::$ty).into()
+            }
+
+            fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                json_schema!({
+                    "type": "string",
+                    "format": $format
+                })
+            }
+        }
+    };
+}
+
+formatted_string_impl!(Date, "date");
+formatted_string_impl!(PrimitiveDateTime, "partial-date-time");
+formatted_string_impl!(Time, "time");
+formatted_string_impl!(OffsetDateTime, "date-time");

--- a/schemars/src/json_schema_impls/time03.rs
+++ b/schemars/src/json_schema_impls/time03.rs
@@ -16,7 +16,7 @@ macro_rules! formatted_string_impl {
             }
 
             fn schema_id() -> Cow<'static, str>  {
-                stringify!(chrono::$ty).into()
+                stringify!(time::$ty).into()
             }
 
             fn json_schema(_: &mut SchemaGenerator) -> Schema {

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -68,6 +68,9 @@ mod prelude {
 
 mod test_helper;
 
+#[cfg(feature = "time03")]
+mod time;
+
 #[macro_export]
 macro_rules! test_name {
     () => {{

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/time.rs~time.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/time.rs~time.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TimeTypes",
+  "type": "object",
+  "properties": {
+    "offset_date_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "primitive_date_time": {
+      "type": "string",
+      "format": "partial-date-time"
+    },
+    "time": {
+      "type": "string",
+      "format": "time"
+    }
+  },
+  "required": [
+    "offset_date_time",
+    "date",
+    "primitive_date_time",
+    "time"
+  ]
+}

--- a/schemars/tests/integration/time.rs
+++ b/schemars/tests/integration/time.rs
@@ -1,0 +1,42 @@
+use crate::prelude::*;
+use time03::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+#[derive(JsonSchema, Serialize, Deserialize)]
+struct TimeTypes {
+    offset_date_time: OffsetDateTime,
+    date: Date,
+    primitive_date_time: PrimitiveDateTime,
+    time: Time,
+}
+
+#[test]
+fn time() {
+    test!(TimeTypes).assert_snapshot();
+
+    test!(OffsetDateTime)
+        // .assert_allows_ser_roundtrip_default()
+        // JSON Schema only allows dates with 4-digit years
+        // .assert_allows_ser_roundtrip([OffsetDateTime::new_in_offset(Date::MIN, Time::MIDNIGHT, UtcOffset::UTC), OffsetDateTime::new_in_offset(Date::MAX, Time::MAX, UtcOffset::UTC)])
+        .assert_matches_de_roundtrip(arbitrary_values());
+
+    test!(Date)
+        // JSON Schema only allows dates with 4-digit years
+        // .assert_allows_ser_roundtrip([Date::MIN, Date::MAX])
+        .assert_matches_de_roundtrip(arbitrary_values());
+
+    test!(PrimitiveDateTime)
+        // JSON Schema only allows dates with 4-digit years
+        // .assert_allows_ser_roundtrip([PrimitiveDateTime::MIN, PrimitiveDateTime::MAX])
+        .assert_matches_de_roundtrip(arbitrary_values_except(
+            Value::is_string,
+            "Custom format 'primitive-date-time', so arbitrary strings technically allowed by schema",
+        ));
+
+    test!(Time)
+        // .assert_allows_ser_roundtrip([Time::MIDNIGHT, Time::MAX])
+        .assert_matches_de_roundtrip(arbitrary_values_except(
+            Value::is_string,
+            "Custom format 'time', so arbitrary strings technically allowed by schema",
+        ));
+
+}

--- a/schemars/tests/integration/time.rs
+++ b/schemars/tests/integration/time.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use time03::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+use time03::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 
 #[derive(JsonSchema, Serialize, Deserialize)]
 struct TimeTypes {


### PR DESCRIPTION
This pull request adds support for the `time` crate version 0.3 (as the optional `time03` feature) to Schemars, allowing types from `time` (such as `Date`, `Time`, `PrimitiveDateTime`, and `OffsetDateTime`) to implement `JsonSchema`. It also includes tests and documentation updates for this new feature.

**Support for the `time03` feature:**

* Added `time03` as an optional dependency in `schemars/Cargo.toml`, with and without the `serde` feature for normal and testing builds. [[1]](diffhunk://#diff-097f126889024dddd3a6392b1d8f43571e590f6e380095e3438e710249ad1bdcR36) [[2]](diffhunk://#diff-097f126889024dddd3a6392b1d8f43571e590f6e380095e3438e710249ad1bdcR62)
* Updated the documentation in `README.md` to mention the new `time03` feature flag.

**Implementation for `time03` types:**

* Added a new module `time03.rs` implementing `JsonSchema` for `Date`, `Time`, `PrimitiveDateTime`, and `OffsetDateTime`, mapping them to appropriate JSON Schema string formats.
* Registered the new module behind the `time03` feature flag in `mod.rs`.

**Testing:**

* Added integration tests for the new `time03` types in `time.rs`, including snapshot testing and roundtrip checks.
* Added a corresponding snapshot file for the expected JSON Schema output.
* Registered the new test module in the integration test harness.