### PR TITLE
Set `#[must_use]` on pure functions

### DIFF
--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -116,6 +116,7 @@ impl<T: Serialize> MaybeSerializeWrapper<T> {
 }
 
 /// Create a schema for a unit enum variant
+#[must_use] 
 pub fn new_unit_enum_variant(variant: &str) -> Schema {
     json_schema!({
         "type": "string",
@@ -143,6 +144,7 @@ macro_rules! _schemars_maybe_schema_id {
 pub struct MaybeJsonSchemaWrapper<T: ?Sized>(core::marker::PhantomData<T>);
 
 pub trait NoJsonSchema {
+    #[must_use] 
     fn maybe_schema_id() -> Cow<'static, str> {
         Cow::Borrowed(core::any::type_name::<Self>())
     }
@@ -151,6 +153,7 @@ pub trait NoJsonSchema {
 impl<T: ?Sized> NoJsonSchema for T {}
 
 impl<T: JsonSchema + ?Sized> MaybeJsonSchemaWrapper<T> {
+    #[must_use] 
     pub fn maybe_schema_id() -> Cow<'static, str> {
         T::schema_id()
     }
@@ -158,6 +161,7 @@ impl<T: JsonSchema + ?Sized> MaybeJsonSchemaWrapper<T> {
 
 /// Create a schema for an externally tagged enum variant
 #[allow(clippy::needless_pass_by_value)]
+#[must_use] 
 pub fn new_externally_tagged_enum_variant(variant: &str, sub_schema: Schema) -> Schema {
     // TODO: this can be optimised by inserting the `sub_schema` as a `Value` rather than
     // using the `json_schema!` macro which borrows and serializes the sub_schema

--- a/schemars/src/_private/rustdoc.rs
+++ b/schemars/src/_private/rustdoc.rs
@@ -1,3 +1,4 @@
+#[must_use]
 pub const fn get_title_and_description(doc: &str) -> (&str, &str) {
     let doc_bytes = trim_ascii(doc.as_bytes());
 

--- a/schemars/src/encoding.rs
+++ b/schemars/src/encoding.rs
@@ -3,6 +3,7 @@ use alloc::borrow::Cow;
 use core::fmt::Write as _;
 
 /// Encodes a string for insertion into a JSON Pointer in URI fragment representation.
+#[must_use]
 pub fn encode_ref_name(name: &str) -> Cow<'_, str> {
     fn needs_encoding(byte: u8) -> bool {
         match byte {
@@ -40,6 +41,7 @@ pub fn encode_ref_name(name: &str) -> Cow<'_, str> {
 
 /// Percent-decodes the given string, returning `None` if it results in invalid UTF-8.
 /// A `%` that is not followed by two hex digits is treated as a literal `%`.
+#[must_use]
 pub fn percent_decode(s: &str) -> Option<Cow<'_, str>> {
     if s.contains('%') {
         let mut buf = Vec::<u8>::new();

--- a/schemars/src/generate.rs
+++ b/schemars/src/generate.rs
@@ -74,6 +74,7 @@ impl Default for SchemaSettings {
 
 impl SchemaSettings {
     /// Creates `SchemaSettings` that conform to [JSON Schema Draft 7](https://json-schema.org/specification-links#draft-7).
+    #[must_use]
     pub fn draft07() -> SchemaSettings {
         SchemaSettings {
             definitions_path: "/definitions".into(),
@@ -90,6 +91,7 @@ impl SchemaSettings {
     }
 
     /// Creates `SchemaSettings` that conform to [JSON Schema 2019-09](https://json-schema.org/specification-links#draft-2019-09-(formerly-known-as-draft-8)).
+    #[must_use]
     pub fn draft2019_09() -> SchemaSettings {
         SchemaSettings {
             definitions_path: "/$defs".into(),
@@ -102,6 +104,7 @@ impl SchemaSettings {
     }
 
     /// Creates `SchemaSettings` that conform to [JSON Schema 2020-12](https://json-schema.org/specification-links#2020-12).
+    #[must_use]
     pub fn draft2020_12() -> SchemaSettings {
         SchemaSettings {
             definitions_path: "/$defs".into(),
@@ -114,6 +117,7 @@ impl SchemaSettings {
     }
 
     /// Creates `SchemaSettings` that conform to [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#schema).
+    #[must_use]
     pub fn openapi3() -> SchemaSettings {
         SchemaSettings {
             definitions_path: "/components/schemas".into(),
@@ -147,6 +151,7 @@ impl SchemaSettings {
     /// });
     /// let generator = settings.into_generator();
     /// ```
+    #[must_use]
     pub fn with(mut self, configure_fn: impl FnOnce(&mut Self)) -> Self {
         configure_fn(&mut self);
         self
@@ -154,23 +159,27 @@ impl SchemaSettings {
 
     /// Appends the given transform to the list of [transforms](SchemaSettings::transforms) for
     /// these `SchemaSettings`.
+    #[must_use]
     pub fn with_transform(mut self, transform: impl Transform + Clone + 'static + Send) -> Self {
         self.transforms.push(Box::new(transform));
         self
     }
 
     /// Creates a new [`SchemaGenerator`] using these settings.
+    #[must_use]
     pub fn into_generator(self) -> SchemaGenerator {
         SchemaGenerator::new(self)
     }
 
     /// Updates the settings to generate schemas describing how types are **deserialized**.
+    #[must_use]
     pub fn for_deserialize(mut self) -> Self {
         self.contract = Contract::Deserialize;
         self
     }
 
     /// Updates the settings to generate schemas describing how types are **serialized**.
+    #[must_use]
     pub fn for_serialize(mut self) -> Self {
         self.contract = Contract::Serialize;
         self
@@ -192,11 +201,13 @@ pub enum Contract {
 
 impl Contract {
     /// Returns true if `self` is the `Deserialize` contract.
+    #[must_use]
     pub fn is_deserialize(&self) -> bool {
         self == &Contract::Deserialize
     }
 
     /// Returns true if `self` is the `Serialize` contract.
+    #[must_use]
     pub fn is_serialize(&self) -> bool {
         self == &Contract::Serialize
     }
@@ -258,6 +269,7 @@ impl From<SchemaSettings> for SchemaGenerator {
 
 impl SchemaGenerator {
     /// Creates a new `SchemaGenerator` using the given settings.
+    #[must_use]
     pub fn new(settings: SchemaSettings) -> SchemaGenerator {
         SchemaGenerator {
             settings,
@@ -280,6 +292,7 @@ impl SchemaGenerator {
     ///
     /// assert_eq!(settings.inline_subschemas, false);
     /// ```
+    #[must_use]
     pub fn settings(&self) -> &SchemaSettings {
         &self.settings
     }
@@ -388,6 +401,7 @@ impl SchemaGenerator {
     ///
     /// The keys of the returned `Map` are the [schema names](JsonSchema::schema_name), and the
     /// values are the schemas themselves.
+    #[must_use]
     pub fn definitions(&self) -> &JsonMap<String, Value> {
         &self.definitions
     }
@@ -397,6 +411,7 @@ impl SchemaGenerator {
     ///
     /// The keys of the returned `Map` are the [schema names](JsonSchema::schema_name), and the
     /// values are the schemas themselves.
+    #[must_use]
     pub fn definitions_mut(&mut self) -> &mut JsonMap<String, Value> {
         &mut self.definitions
     }
@@ -461,6 +476,7 @@ impl SchemaGenerator {
     /// If `T`'s schema depends on any [non-inlined](JsonSchema::inline_schema) schemas, then
     /// this method will include them in the returned `Schema` at the [definitions
     /// path](SchemaSettings::definitions_path) (by default `"$defs"`).
+    #[must_use]
     pub fn into_root_schema_for<T: ?Sized + JsonSchema>(mut self) -> Schema {
         let schema_uid = self.schema_uid::<T>();
         self.root_schema_id_stack.push(schema_uid.clone());
@@ -553,6 +569,7 @@ impl SchemaGenerator {
     /// `SchemaGenerator`.
     ///
     /// This specifies whether generated schemas describe serialize or *de*serialize behaviour.
+    #[must_use]
     pub fn contract(&self) -> &Contract {
         &self.settings.contract
     }
@@ -680,6 +697,7 @@ pub trait GenTransform: Transform + DynClone + Any + Send {
 #[allow(deprecated, clippy::used_underscore_items)]
 impl dyn GenTransform {
     /// Returns `true` if the inner transform is of type `T`.
+    #[must_use]
     pub fn is<T: Transform + Clone + Any + Send>(&self) -> bool {
         self._as_any().is::<T>()
     }
@@ -700,6 +718,7 @@ impl dyn GenTransform {
     ///
     /// assert_eq!(settings.transforms.len(), original_len - 1);
     /// ```
+    #[must_use]
     pub fn downcast_ref<T: Transform + Clone + Any + Send>(&self) -> Option<&T> {
         self._as_any().downcast_ref::<T>()
     }
@@ -720,6 +739,7 @@ impl dyn GenTransform {
     ///     }
     /// }
     /// ```
+    #[must_use]
     pub fn downcast_mut<T: Transform + Clone + Any + Send>(&mut self) -> Option<&mut T> {
         self._as_any_mut().downcast_mut::<T>()
     }

--- a/schemars/src/lib.rs
+++ b/schemars/src/lib.rs
@@ -7,12 +7,7 @@
     clippy::exhaustive_structs,
     clippy::exhaustive_enums
 )]
-#![allow(
-    clippy::must_use_candidate,
-    clippy::return_self_not_must_use,
-    clippy::wildcard_imports,
-    clippy::missing_errors_doc
-)]
+#![allow(clippy::wildcard_imports, clippy::missing_errors_doc)]
 #![doc = include_str!("../README.md")]
 #![no_std]
 
@@ -146,6 +141,7 @@ pub trait JsonSchema {
     /// infinite cycles when generating schemas.
     ///
     /// By default, this returns `false`.
+    #[must_use]
     fn inline_schema() -> bool {
         false
     }
@@ -154,6 +150,7 @@ pub trait JsonSchema {
     ///
     /// This is used as the title for root schemas, and the key within the root's `definitions`
     /// property for subschemas.
+    #[must_use]
     fn schema_name() -> Cow<'static, str>;
 
     /// Returns a string that uniquely identifies the schema produced by this type.
@@ -165,6 +162,7 @@ pub trait JsonSchema {
     ///
     /// The default implementation returns the same value as
     /// [`schema_name()`](JsonSchema::schema_name).
+    #[must_use]
     fn schema_id() -> Cow<'static, str> {
         Self::schema_name()
     }
@@ -185,6 +183,7 @@ pub trait JsonSchema {
 
     // TODO document and bring into public API?
     #[doc(hidden)]
+    #[must_use]
     fn _schemars_private_is_option() -> bool {
         false
     }

--- a/schemars/src/schema.rs
+++ b/schemars/src/schema.rs
@@ -126,6 +126,7 @@ impl Schema {
     ///
     /// The given reference string should be a URI reference. This will usually be a JSON Pointer
     /// in [URI Fragment representation](https://tools.ietf.org/html/rfc6901#section-6).
+    #[must_use]
     pub fn new_ref(reference: String) -> Self {
         let mut map = Map::new();
         map.insert("$ref".to_owned(), Value::String(reference));
@@ -133,23 +134,27 @@ impl Schema {
     }
 
     /// Borrows the `Schema`'s underlying JSON value.
+    #[must_use]
     pub fn as_value(&self) -> &Value {
         &self.0
     }
 
     /// If the `Schema`'s underlying JSON value is a bool, returns the bool value.
+    #[must_use]
     pub fn as_bool(&self) -> Option<bool> {
         self.0.as_bool()
     }
 
     /// If the `Schema`'s underlying JSON value is an object, borrows the object as a `Map` of
     /// properties.
+    #[must_use]
     pub fn as_object(&self) -> Option<&Map<String, Value>> {
         self.0.as_object()
     }
 
     /// If the `Schema`'s underlying JSON value is an object, mutably borrows the object as a `Map`
     /// of properties.
+    #[must_use]
     pub fn as_object_mut(&mut self) -> Option<&mut Map<String, Value>> {
         self.0.as_object_mut()
     }
@@ -171,6 +176,7 @@ impl Schema {
     }
 
     /// Returns the `Schema`'s underlying JSON value.
+    #[must_use]
     pub fn to_value(self) -> Value {
         self.0
     }
@@ -238,6 +244,7 @@ impl Schema {
     /// let bool_schema = json_schema!(true);
     /// assert_eq!(bool_schema.get("type"), None);
     /// ```
+    #[must_use]
     pub fn get<Q>(&self, key: &Q) -> Option<&Value>
     where
         String: core::borrow::Borrow<Q>,
@@ -262,6 +269,7 @@ impl Schema {
     /// }
     /// assert_eq!(obj_schema, json_schema!({ "properties": { "anything": true } }));
     /// ```
+    #[must_use]
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Value>
     where
         String: core::borrow::Borrow<Q>,
@@ -298,6 +306,7 @@ impl Schema {
     /// assert_eq!(schema.pointer("#/$defs/%F0%9F%9A%80").unwrap(), &json!(true));
     /// assert_eq!(schema.pointer("/does/not/exist"), None);
     /// ```
+    #[must_use]
     pub fn pointer(&self, pointer: &str) -> Option<&Value> {
         if let Some(percent_encoded) = pointer.strip_prefix('#') {
             let decoded = crate::encoding::percent_decode(percent_encoded)?;
@@ -335,6 +344,7 @@ impl Schema {
     /// assert_eq!(schema.pointer_mut("#/$defs/%F0%9F%9A%80").unwrap(), &json!(true));
     /// assert_eq!(schema.pointer_mut("/does/not/exist"), None);
     /// ```
+    #[must_use]
     pub fn pointer_mut(&mut self, pointer: &str) -> Option<&mut Value> {
         if let Some(percent_encoded) = pointer.strip_prefix('#') {
             let decoded = crate::encoding::percent_decode(percent_encoded)?;


### PR DESCRIPTION
Any call to these functions that doesn't use the return value is probably a mistake