### PR TITLE
Add ordered-float support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +886,25 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+ "serde",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -985,6 +1015,7 @@ dependencies = [
  "indexmap",
  "jiff",
  "jsonschema",
+ "ordered-float",
  "pretty_assertions",
  "ref-cast",
  "regex",

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `smol_str02` - [smol_str](https://crates.io/crates/smol_str) (^0.2.1)
 - `url2` - [url](https://crates.io/crates/url) (^2.0)
 - `uuid1` - [uuid](https://crates.io/crates/uuid) (^1.0)
+- `ordered-float` - [ordered-float](https://crates.io/crates/ordered-float) (^5.0)
 
 Bear in mind that each of these feature flags _may_ be removed in a future semver-minor change of Schemars, particularly if a newer semver-incompatible version of the external library has been released for a long time. This is unfortunately necessary to avoid supporting old/unmaintained libraries indefinitely.
 

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -33,6 +33,7 @@ smallvec1 = { version = "1.0", default-features = false, optional = true, packag
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+ordered-float = { version = "5", default-features = false, optional = true, package = "ordered-float" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -58,6 +59,7 @@ smallvec1 = { version = "1.0", default-features = false, features = ["serde"], p
 smol_str02 = { version = "0.2.1", default-features = false, features = ["serde"], package = "smol_str" }
 url2 = { version = "2.0", default-features = false, features = ["serde", "std"], package = "url" }
 uuid1 = { version = "1.0", default-features = false, features = ["serde"], package = "uuid" }
+ordered-float = { version = "5", features = ["serde"], package = "ordered-float" }
 
 [features]
 default = ["derive", "std"]

--- a/schemars/src/json_schema_impls/primitives.rs
+++ b/schemars/src/json_schema_impls/primitives.rs
@@ -135,3 +135,17 @@ impl JsonSchema for char {
         })
     }
 }
+
+#[cfg(feature = "ordered-float")]
+impl<T: JsonSchema> JsonSchema for ordered_float::OrderedFloat<T> {
+    inline_schema!();
+
+    fn schema_name() -> Cow<'static, str> {
+        T::schema_name()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        T::json_schema(gen)
+    }
+}
+

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -58,6 +58,8 @@ mod url;
 #[cfg(feature = "uuid1")]
 mod uuid;
 mod validator;
+#[cfg(feature = "ordered-float")]
+mod ordered_float;
 
 mod prelude {
     pub(crate) use crate::test;

--- a/schemars/tests/integration/ordered_float.rs
+++ b/schemars/tests/integration/ordered_float.rs
@@ -1,0 +1,11 @@
+use ordered_float::OrderedFloat;
+
+use crate::prelude::*;
+
+#[test]
+fn ordered_float() {
+    test!(OrderedFloat<f64>)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([OrderedFloat(0.0), OrderedFloat(1.0)])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/ordered_float.rs~ordered_float.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/ordered_float.rs~ordered_float.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "double",
+  "type": "number",
+  "format": "double"
+}


### PR DESCRIPTION
This PR adds support for the ordered-float library. It treats them like the underlying float value they wrap. It doesn't support NaN's since these are not supported elsewhere in this library.