### PR TITLE
Add `smol_str03` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,8 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "smallvec",
- "smol_str",
+ "smol_str 0.2.2",
+ "smol_str 0.3.2",
  "snapbox",
  "trybuild",
  "url",
@@ -1031,18 +1032,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1113,6 +1124,15 @@ name = "smol_str"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
  "serde",
 ]

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `semver1` - [semver](https://crates.io/crates/semver) (^1.0.9)
 - `smallvec1` - [smallvec](https://crates.io/crates/smallvec) (^1.0)
 - `smol_str02` - [smol_str](https://crates.io/crates/smol_str) (^0.2.1)
+- `smol_str03` - [smol_str](https://crates.io/crates/smol_str) (^0.3)
 - `url2` - [url](https://crates.io/crates/url) (^2.0)
 - `uuid1` - [uuid](https://crates.io/crates/uuid) (^1.0)
 

--- a/docs/0-migrating.md
+++ b/docs/0-migrating.md
@@ -23,7 +23,7 @@ All optional dependencies are now suffixed by their version:
 - `url` is now `url2`
 - `bytes` is now `bytes1`
 - `rust_decimal` is now `rust_decimal1`
-- `smol_str` is now `smol_str02`
+- `smol_str` is now `smol_str02` or `smol_str03`
 - `semver` is now `semver1`
 - `enumset`, `indexmap`, `uuid08`, `arrayvec05` and `bigdecimal03` have been removed
 - `indexmap2`, `arrayvec07` and `bigdecimal04` are unchanged

--- a/docs/4-features.md
+++ b/docs/4-features.md
@@ -24,6 +24,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `semver1` - [semver](https://crates.io/crates/semver) (^1.0.9)
 - `smallvec1` - [smallvec](https://crates.io/crates/smallvec) (^1.0)
 - `smol_str02` - [smol_str](https://crates.io/crates/smol_str) (^0.2.1)
+- `smol_str03` - [smol_str](https://crates.io/crates/smol_str) (^0.3)
 - `url2` - [url](https://crates.io/crates/url) (^2.0)
 - `uuid1` - [uuid](https://crates.io/crates/uuid) (^1.0)
 

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.74"
 
 [dependencies]
 schemars_derive = { version = "=1.1.0", optional = true, path = "../schemars_derive" }
-serde = { version = "1.0.194", default-features = false, features = ["alloc"]}
-serde_json = { version =  "1.0.127", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.194", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.127", default-features = false, features = ["alloc"] }
 dyn-clone = "1.0.17"
 ref-cast = "1.0.22"
 
@@ -31,6 +31,7 @@ rust_decimal1 = { version = "1.13", default-features = false, optional = true, p
 semver1 = { version = "1.0.9", default-features = false, optional = true, package = "semver" }
 smallvec1 = { version = "1.0", default-features = false, optional = true, package = "smallvec" }
 smol_str02 = { version = "0.2.1", default-features = false, optional = true, package = "smol_str" }
+smol_str03 = { version = "0.3.2", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
 
@@ -45,7 +46,7 @@ garde = { version = "0.22", features = ["derive", "email", "regex", "url"] }
 validator = { version = "0.20", features = ["derive"] }
 regex = { version = "1.10.6", default-features = false }
 
-arrayvec07 = { version = "0.7", default-features = false, features = ["serde"], package = "arrayvec"}
+arrayvec07 = { version = "0.7", default-features = false, features = ["serde"], package = "arrayvec" }
 bigdecimal04 = { version = "0.4", default-features = false, features = ["serde"], package = "bigdecimal" }
 bytes1 = { version = "1.0", default-features = false, features = ["serde"], package = "bytes" }
 chrono04 = { version = "0.4", default-features = false, features = ["serde"], package = "chrono" }
@@ -56,6 +57,7 @@ rust_decimal1 = { version = "1", default-features = false, features = ["serde"],
 semver1 = { version = "1.0.9", default-features = false, features = ["serde"], package = "semver" }
 smallvec1 = { version = "1.0", default-features = false, features = ["serde"], package = "smallvec" }
 smol_str02 = { version = "0.2.1", default-features = false, features = ["serde"], package = "smol_str" }
+smol_str03 = { version = "0.3.2", default-features = false, features = ["serde"], package = "smol_str" }
 url2 = { version = "2.0", default-features = false, features = ["serde", "std"], package = "url" }
 uuid1 = { version = "1.0", default-features = false, features = ["serde"], package = "uuid" }
 
@@ -72,7 +74,7 @@ derive = ["schemars_derive"]
 # Preserves order of properties inserted into a `Schema`.
 # When deriving `JsonSchema`, this ensures that the `properties` entires match
 # the order of the fields in the struct definition.
-preserve_order  = ["serde_json/preserve_order"]
+preserve_order = ["serde_json/preserve_order"]
 
 # Implements `JsonSchema` on `serde_json::value::RawValue`
 raw_value = ["serde_json/raw_value"]
@@ -86,4 +88,3 @@ required-features = ["_ui_test"]
 
 [package.metadata.docs.rs]
 all-features = true
-

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -87,6 +87,9 @@ forward_impl!((<A: smallvec1::Array> crate::JsonSchema for smallvec1::SmallVec<A
 #[cfg(feature = "smol_str02")]
 forward_impl!(smol_str02::SmolStr => alloc::string::String);
 
+#[cfg(feature = "smol_str03")]
+forward_impl!(smol_str03::SmolStr => alloc::string::String);
+
 #[cfg(feature = "url2")]
 mod url2;
 

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -46,7 +46,7 @@ mod settings;
 mod skip;
 #[cfg(feature = "smallvec1")]
 mod smallvec;
-#[cfg(feature = "smol_str02")]
+#[cfg(any(feature = "smol_str02", feature = "smol_str03"))]
 mod smol_str;
 mod std_types;
 mod structs;

--- a/schemars/tests/integration/smol_str.rs
+++ b/schemars/tests/integration/smol_str.rs
@@ -1,10 +1,18 @@
-use smol_str02::SmolStr;
-
 use crate::prelude::*;
 
+#[cfg(feature = "smol_str02")]
 #[test]
-fn smol_str() {
-    test!(SmolStr)
+fn smol_str02() {
+    test!(smol_str02::SmolStr)
+        .assert_identical::<String>()
+        .assert_allows_ser_roundtrip(["".into(), "test".into()])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[cfg(feature = "smol_str03")]
+#[test]
+fn smol_str03() {
+    test!(smol_str03::SmolStr)
         .assert_identical::<String>()
         .assert_allows_ser_roundtrip(["".into(), "test".into()])
         .assert_matches_de_roundtrip(arbitrary_values());


### PR DESCRIPTION
This pull request adds support for the `smol_str` crate version 0.3 (`smol_str03`) as an optional dependency alongside the existing support for version 0.2 (`smol_str02`). The documentation, Cargo configuration, and test suite have all been updated to reflect and validate this new compatibility.

Closes #490
