### PR TITLE
feat(maps): set propertyNames for string map keys and support oneOf

### DIFF
--- a/schemars/tests/integration/map.rs
+++ b/schemars/tests/integration/map.rs
@@ -18,6 +18,17 @@ enum Enum {
     UntaggedIndirectU32(IndirectU32),
 }
 
+/// An enum with documentation comments on its variants.
+#[derive(JsonSchema, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum SimpleEnumWithDocComments {
+    /// Variant A
+    A,
+    /// Variant B
+    B,
+    /// Variant C
+    C,
+}
+
 #[derive(JsonSchema, Deserialize, Serialize, Default)]
 struct Maps {
     s_map: HashMap<String, bool>,
@@ -25,6 +36,7 @@ struct Maps {
     u_map: HashMap<u64, bool>,
     pattern_map: BTreeMap<HexNumber, bool>,
     enum_map: HashMap<Enum, bool>,
+    enum_map_docs: HashMap<SimpleEnumWithDocComments, bool>,
 }
 
 #[test]
@@ -37,6 +49,7 @@ fn maps() {
             u_map: HashMap::from_iter([(123, true)]),
             pattern_map: BTreeMap::from_iter([(HexNumber("b4df00d".to_owned()), true)]),
             enum_map: HashMap::from_iter([(Enum::Unit1, true)]),
+            enum_map_docs: HashMap::from_iter([(SimpleEnumWithDocComments::A, true)]),
         }])
         .assert_allows_ser_only(
             // serde allow serializing untagged non-string newtype variants, but not deserializing them.

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/map.rs~maps.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/map.rs~maps.json
@@ -34,6 +34,10 @@
         "^[0-9a-f]*$": {
           "type": "boolean"
         }
+      },
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[0-9a-f]*$"
       }
     },
     "enum_map": {
@@ -52,6 +56,32 @@
           "type": "boolean"
         }
       }
+    },
+    "enum_map_docs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "propertyNames": {
+        "description": "An enum with documentation comments on its variants.",
+        "oneOf": [
+          {
+            "description": "Variant A",
+            "type": "string",
+            "const": "A"
+          },
+          {
+            "description": "Variant B",
+            "type": "string",
+            "const": "B"
+          },
+          {
+            "description": "Variant C",
+            "type": "string",
+            "const": "C"
+          }
+        ]
+      }
     }
   },
   "required": [
@@ -59,7 +89,8 @@
     "i_map",
     "u_map",
     "pattern_map",
-    "enum_map"
+    "enum_map",
+    "enum_map_docs"
   ],
   "$defs": {
     "IndirectU32": {


### PR DESCRIPTION
This PR:

1. Implements the `propertyNames` field for map schemas (similar to #384), but with validation logic to only add it for string-typed keys. This avoids validator confusion (as in the test suite) with non-string key types.
2. Adds support for `oneOf` in addition to `anyOf`  (added via #452) when analyzing map key schemas. This enables proper handling of enums with documentation comments, which generate `oneOf` schemas instead of `anyOf`.