### PR TITLE
Add fastnum implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bnum"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +300,15 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fastnum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
+dependencies = [
+ "bnum",
 ]
 
 [[package]]
@@ -981,6 +996,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "either",
+ "fastnum",
  "garde",
  "indexmap",
  "jiff",

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -34,6 +34,7 @@ smol_str02 = { version = "0.2.1", default-features = false, optional = true, pac
 smol_str03 = { version = "0.3.2", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+fastnum07 = { version = "0.7", default-features = false, optional = true, package = "fastnum" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/schemars/src/json_schema_impls/decimal.rs
+++ b/schemars/src/json_schema_impls/decimal.rs
@@ -35,3 +35,13 @@ macro_rules! decimal_impl {
 decimal_impl!(rust_decimal1::Decimal);
 #[cfg(feature = "bigdecimal04")]
 decimal_impl!(bigdecimal04::BigDecimal);
+#[cfg(feature = "fastnum07")]
+mod fastnum_07 {
+    use super::*;
+    decimal_impl!(fastnum07::decimal::UnsignedDecimal<2>);
+    decimal_impl!(fastnum07::decimal::UnsignedDecimal<4>);
+    decimal_impl!(fastnum07::decimal::UnsignedDecimal<8>);
+    decimal_impl!(fastnum07::decimal::Decimal<2>);
+    decimal_impl!(fastnum07::decimal::Decimal<4>);
+    decimal_impl!(fastnum07::decimal::Decimal<8>);
+}

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -66,7 +66,11 @@ mod bytes1;
 #[cfg(feature = "chrono04")]
 mod chrono04;
 
-#[cfg(any(feature = "rust_decimal1", feature = "bigdecimal04"))]
+#[cfg(any(
+    feature = "rust_decimal1",
+    feature = "bigdecimal04",
+    feature = "fastnum07"
+))]
 mod decimal;
 
 #[cfg(feature = "either1")]


### PR DESCRIPTION
I added the implementation for [Fastnum](https://docs.rs/fastnum/latest/fastnum/).

It's another crate for decimal numbers.
I could have done a more precise job on the De/Serialize regex for Unsigned values, but want to keep the changes to the minimum.

I did test it on my project, using aide, it matched expectations.

<details>

<summary>Workaround I used if it helps someone in the same situation</summary>

```rust
use std::borrow::Cow;

use schemars::{Schema, SchemaGenerator, generate::Contract};
use serde::{Deserialize, Serialize};

#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
pub struct JsonUDecimal(fastnum::decimal::UnsignedDecimal<4>);

impl schemars::JsonSchema for JsonUDecimal {
    fn schema_name() -> Cow<'static, str> {
        "UDecimal".into()
    }

    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
        let (ty, pattern) = match generator.contract() {
            Contract::Deserialize => ("string".into(), r"^\d+(\.\d+)?([eE]\d+)?$".into()),
            Contract::Serialize => ("string".into(), r"^\d+(\.\d+)?$".into()),
            // Contract is marked as non_exhaustive
            _ => unimplemented!("New version of Schemars introduced a new contract type"),
        };

        let mut result = Schema::default();
        result.insert("type".to_owned(), ty);
        result.insert("pattern".to_owned(), pattern);
        result
    }
}

impl From<fastnum::decimal::UnsignedDecimal<4>> for JsonUDecimal {
    fn from(value: fastnum::decimal::UnsignedDecimal<4>) -> Self {
        Self(value)
    }
}
```
</details>