### PR TITLE
Add uuid::fmt module impls

### DIFF
--- a/schemars/src/json_schema_impls/uuid1.rs
+++ b/schemars/src/json_schema_impls/uuid1.rs
@@ -21,3 +21,71 @@ impl JsonSchema for Uuid {
         })
     }
 }
+
+impl JsonSchema for uuid1::fmt::Simple {
+    fn schema_name() -> Cow<'static, str> {
+        "Simple".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "uuid::fmt::Simple".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^[0-9a-f]{32}$"
+        })
+    }
+}
+
+impl JsonSchema for uuid1::fmt::Braced {
+    fn schema_name() -> Cow<'static, str> {
+        "Braced".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "uuid::fmt::Braced".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}$",
+        })
+    }
+}
+
+impl JsonSchema for uuid1::fmt::Hyphenated {
+    fn schema_name() -> Cow<'static, str> {
+        "Hyphenated".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "uuid::fmt::Hyphenated".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "format": "uuid",
+        })
+    }
+}
+
+impl JsonSchema for uuid1::fmt::Urn {
+    fn schema_name() -> Cow<'static, str> {
+        "Urn".into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        "uuid::fmt::Urn".into()
+    }
+
+    fn json_schema(_: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "pattern": r"^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        })
+    }
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~braced_uuid.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~braced_uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Braced",
+  "type": "string",
+  "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~hyphenated_uuid.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~hyphenated_uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Hyphenated",
+  "type": "string",
+  "format": "uuid"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~simple_uuid.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~simple_uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Simple",
+  "type": "string",
+  "pattern": "^[0-9a-f]{32}$"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~urn_uuid.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/uuid.rs~urn_uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Urn",
+  "type": "string",
+  "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+}

--- a/schemars/tests/integration/uuid.rs
+++ b/schemars/tests/integration/uuid.rs
@@ -1,10 +1,40 @@
 use crate::prelude::*;
 use uuid1::Uuid;
 
+const CASES: [Uuid; 3] = [Uuid::nil(), Uuid::max(), Uuid::from_u128(1234567890)];
+
 #[test]
 fn uuid() {
     test!(Uuid)
         .assert_snapshot()
-        .assert_allows_ser_roundtrip([Uuid::nil(), Uuid::max(), Uuid::from_u128(1234567890)])
+        .assert_allows_ser_roundtrip(CASES)
         .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn braced_uuid() {
+    test!(uuid1::fmt::Braced)
+        .assert_snapshot()
+        .assert_allows_ser_only(CASES.into_iter().map(uuid1::fmt::Braced::from_uuid));
+}
+
+#[test]
+fn hyphenated_uuid() {
+    test!(uuid1::fmt::Hyphenated)
+        .assert_snapshot()
+        .assert_allows_ser_only(CASES.into_iter().map(uuid1::fmt::Hyphenated::from_uuid));
+}
+
+#[test]
+fn simple_uuid() {
+    test!(uuid1::fmt::Simple)
+        .assert_snapshot()
+        .assert_allows_ser_only(CASES.into_iter().map(uuid1::fmt::Simple::from_uuid));
+}
+
+#[test]
+fn urn_uuid() {
+    test!(uuid1::fmt::Urn)
+        .assert_snapshot()
+        .assert_allows_ser_only(CASES.into_iter().map(uuid1::fmt::Urn::from_uuid));
 }


### PR DESCRIPTION
The uuid package has Simple, Braced, Hyphenated and Urn uuid formats, which are useful if you are working with systems that expect uuid's in these particular formats.

This PR adds JsonSchema impl's for these 4 types under the uuid::fmt module of the uuid crate.