### PR TITLE
Add support for `ordermap` behind `"ordermap" feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "icu_collections"
@@ -529,13 +529,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -771,6 +772,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ordermap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +997,7 @@ dependencies = [
  "indexmap",
  "jiff",
  "jsonschema",
+ "ordermap",
  "pretty_assertions",
  "ref-cast",
  "regex",

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `chrono04` - [chrono](https://crates.io/crates/chrono) (^0.4)
 - `either1` - [either](https://crates.io/crates/either) (^1.3)
 - `indexmap2` - [indexmap](https://crates.io/crates/indexmap) (^2.0)
+- `ordermap` - [indexmap](https://crates.io/crates/ordermap) (^1.1)
 - `jiff02` - [jiff](https://crates.io/crates/jiff) (^0.2)
 - `rust_decimal1` - [rust_decimal](https://crates.io/crates/rust_decimal) (^1.0)
 - `semver1` - [semver](https://crates.io/crates/semver) (^1.0.9)

--- a/docs/4-features.md
+++ b/docs/4-features.md
@@ -19,6 +19,7 @@ Schemars can implement `JsonSchema` on types from several popular crates, enable
 - `chrono04` - [chrono](https://crates.io/crates/chrono) (^0.4)
 - `either1` - [either](https://crates.io/crates/either) (^1.3)
 - `indexmap2` - [indexmap](https://crates.io/crates/indexmap) (^2.0)
+- `ordermap` - [indexmap](https://crates.io/crates/ordermap) (^1.1)
 - `jiff02` - [jiff](https://crates.io/crates/jiff) (^0.2)
 - `rust_decimal1` - [rust_decimal](https://crates.io/crates/rust_decimal) (^1.0)
 - `semver1` - [semver](https://crates.io/crates/semver) (^1.0.9)

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -26,6 +26,7 @@ bytes1 = { version = "1.0", default-features = false, optional = true, package =
 chrono04 = { version = "0.4.39", default-features = false, optional = true, package = "chrono" }
 either1 = { version = "1.3", default-features = false, optional = true, package = "either" }
 indexmap2 = { version = "2.2.3", default-features = false, optional = true, package = "indexmap" }
+ordermap = { version = "1.1.0", default-features = false, optional = true, package = "ordermap" }
 jiff02 = { version = "0.2", default-features = false, optional = true, package = "jiff" }
 rust_decimal1 = { version = "1.13", default-features = false, optional = true, package = "rust_decimal" }
 semver1 = { version = "1.0.9", default-features = false, optional = true, package = "semver" }
@@ -52,6 +53,7 @@ bytes1 = { version = "1.0", default-features = false, features = ["serde"], pack
 chrono04 = { version = "0.4", default-features = false, features = ["serde"], package = "chrono" }
 either1 = { version = "1.3", default-features = false, features = ["serde"], package = "either" }
 indexmap2 = { version = "2.0", default-features = false, features = ["serde"], package = "indexmap" }
+ordermap = { version = "1.1", default-features = false, features = ["std", "serde"], package = "ordermap" }
 jiff02 = { version = "0.2", features = ["serde"], package = "jiff" }
 rust_decimal1 = { version = "1", default-features = false, features = ["serde"], package = "rust_decimal" }
 semver1 = { version = "1.0.9", default-features = false, features = ["serde"], package = "semver" }
@@ -78,6 +80,9 @@ preserve_order = ["serde_json/preserve_order"]
 
 # Implements `JsonSchema` on `serde_json::value::RawValue`
 raw_value = ["serde_json/raw_value"]
+
+# ordermap backs onto indexmap2
+ordermap = ["dep:ordermap", "indexmap2"]
 
 # For internal/CI use only
 _ui_test = []

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -75,6 +75,9 @@ mod either1;
 #[cfg(feature = "indexmap2")]
 mod indexmap2;
 
+#[cfg(feature = "ordermap")]
+mod ordermap;
+
 #[cfg(feature = "jiff02")]
 mod jiff02;
 

--- a/schemars/src/json_schema_impls/ordermap.rs
+++ b/schemars/src/json_schema_impls/ordermap.rs
@@ -1,0 +1,6 @@
+use crate::JsonSchema;
+use indexmap2::{IndexMap, IndexSet};
+use ordermap::{OrderMap, OrderSet};
+
+forward_impl!((<K: JsonSchema, V: JsonSchema, H> JsonSchema for OrderMap<K, V, H>) => IndexMap<K, V>);
+forward_impl!((<T: JsonSchema, H> JsonSchema for OrderSet<T, H>) => IndexSet<T>);

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -37,6 +37,8 @@ mod inline_subschemas;
 mod jiff;
 mod macros;
 mod map;
+#[cfg(feature = "ordermap")]
+mod ordermap;
 mod remote_derive;
 mod same_name;
 mod schema_name;

--- a/schemars/tests/integration/ordermap.rs
+++ b/schemars/tests/integration/ordermap.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+use indexmap2::{IndexMap, IndexSet};
+use ordermap::{ordermap, orderset, OrderMap, OrderSet};
+
+#[test]
+fn ordermap() {
+    test!(OrderMap<String, bool>)
+        .assert_identical::<IndexMap<String, bool>>()
+        .assert_allows_ser_roundtrip([ordermap!(), ordermap!("key".to_owned() => true)])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn orderset() {
+    test!(OrderSet<String>)
+        .assert_identical::<IndexSet<String>>()
+        .assert_allows_ser_roundtrip([orderset!(), orderset!("test".to_owned())])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}


### PR DESCRIPTION
* Closes #352

Heya, I've added support for [`ordermap 1.1.0`](https://github.com/indexmap-rs/ordermap) behind the `"ordermap"` feature.

That version of `ordermap` depends on `indexmap 2.13.0`, which [increases the MSRV to 1.82](https://github.com/indexmap-rs/indexmap/blob/2.13.0/Cargo.toml#L11).
