### PR TITLE
Add support for ordered_hash_map 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +393,11 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "icu_collections"
@@ -771,6 +788,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ordered_hash_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5a1cbf49ce5de21ddae71cd1fbe91ff9e38d6a7a9af366fd9be6cea94d856f"
+dependencies = [
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1012,7 @@ dependencies = [
  "indexmap",
  "jiff",
  "jsonschema",
+ "ordered_hash_map",
  "pretty_assertions",
  "ref-cast",
  "regex",

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -34,6 +34,7 @@ smol_str02 = { version = "0.2.1", default-features = false, optional = true, pac
 smol_str03 = { version = "0.3.2", default-features = false, optional = true, package = "smol_str" }
 url2 = { version = "2.0", default-features = false, optional = true, package = "url" }
 uuid1 = { version = "1.0", default-features = false, optional = true, package = "uuid" }
+ordered_hash_map06 = { version = "0.6", default-features = false, optional = true, package = "ordered_hash_map" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -60,6 +61,7 @@ smol_str02 = { version = "0.2.1", default-features = false, features = ["serde"]
 smol_str03 = { version = "0.3.2", default-features = false, features = ["serde"], package = "smol_str" }
 url2 = { version = "2.0", default-features = false, features = ["serde", "std"], package = "url" }
 uuid1 = { version = "1.0", default-features = false, features = ["serde"], package = "uuid" }
+ordered_hash_map06 = { version = "0.6", default-features = false, features = ["serde"], package = "ordered_hash_map" }
 
 [features]
 default = ["derive", "std"]

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -75,6 +75,9 @@ mod either1;
 #[cfg(feature = "indexmap2")]
 mod indexmap2;
 
+#[cfg(feature = "ordered_hash_map06")]
+mod ordered_hash_map06;
+
 #[cfg(feature = "jiff02")]
 mod jiff02;
 

--- a/schemars/src/json_schema_impls/ordered_hash_map06.rs
+++ b/schemars/src/json_schema_impls/ordered_hash_map06.rs
@@ -1,0 +1,6 @@
+use crate::JsonSchema;
+use alloc::collections::{BTreeMap, BTreeSet};
+use ordered_hash_map06::{OrderedHashMap, OrderedHashSet};
+
+forward_impl!((<K: JsonSchema, V: JsonSchema, S> JsonSchema for OrderedHashMap<K, V, S>) => BTreeMap<K, V>);
+forward_impl!((<T: JsonSchema, S> JsonSchema for OrderedHashSet<T, S>) => BTreeSet<T>);

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -32,6 +32,8 @@ mod from_value;
 mod garde;
 #[cfg(feature = "indexmap2")]
 mod indexmap;
+#[cfg(feature = "ordered_hash_map06")]
+mod ordered_hash_map;
 mod inline_subschemas;
 #[cfg(feature = "jiff02")]
 mod jiff;

--- a/schemars/tests/integration/ordered_hash_map.rs
+++ b/schemars/tests/integration/ordered_hash_map.rs
@@ -1,0 +1,31 @@
+use crate::prelude::*;
+use ordered_hash_map06::{OrderedHashMap, OrderedHashSet};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[test]
+fn ordered_hash_map() {
+    let mut map_with_entry = OrderedHashMap::new();
+    map_with_entry.insert("key".to_owned(), true);
+
+    test!(OrderedHashMap<String, bool>)
+        .assert_identical::<BTreeMap<String, bool>>()
+        .assert_allows_ser_roundtrip([
+            OrderedHashMap::new(),
+            map_with_entry,
+        ])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[test]
+fn ordered_hash_set() {
+    let mut set_with_entry = OrderedHashSet::new();
+    set_with_entry.insert("test".to_owned());
+
+    test!(OrderedHashSet<String>)
+        .assert_identical::<BTreeSet<String>>()
+        .assert_allows_ser_roundtrip([
+            OrderedHashSet::new(),
+            set_with_entry,
+        ])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}


### PR DESCRIPTION
The implementation and tests are basically the same as the ones for `indexmap`.

Closes #523 .