### PR TITLE
backport fix for  default + skip_serializing fields marked as required

### DIFF
--- a/schemars/tests/default.rs
+++ b/schemars/tests/default.rs
@@ -53,7 +53,37 @@ struct MyStruct2 {
 #[derive(Default, JsonSchema)]
 struct NotSerialize;
 
+#[allow(dead_code)]
+#[derive(Default, JsonSchema)]
+struct SkipSerializingFields {
+    #[serde(default, skip_serializing)]
+    skipped_default: i32,
+    #[serde(skip_serializing)]
+    skipped_no_default: bool,
+}
+
+#[allow(dead_code)]
+#[derive(Default, JsonSchema)]
+#[serde(default)]
+struct ContainerDefaultSkipSerializingFields {
+    #[serde(skip_serializing)]
+    skipped: i32,
+    not_skipped: bool,
+}
+
 #[test]
 fn schema_default_values() -> TestResult {
     test_default_generated_schema::<MyStruct>("default")
+}
+
+#[test]
+fn schema_default_skip_serializing_fields() -> TestResult {
+    test_default_generated_schema::<SkipSerializingFields>("default_skip_serializing_fields")
+}
+
+#[test]
+fn schema_container_default_skip_serializing_fields() -> TestResult {
+    test_default_generated_schema::<ContainerDefaultSkipSerializingFields>(
+        "default_container_skip_serializing_fields",
+    )
 }

--- a/schemars/tests/expected/default_container_skip_serializing_fields.json
+++ b/schemars/tests/expected/default_container_skip_serializing_fields.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContainerDefaultSkipSerializingFields",
+  "type": "object",
+  "properties": {
+    "not_skipped": {
+      "default": false,
+      "type": "boolean"
+    },
+    "skipped": {
+      "writeOnly": true,
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/schemars/tests/expected/default_skip_serializing_fields.json
+++ b/schemars/tests/expected/default_skip_serializing_fields.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SkipSerializingFields",
+  "type": "object",
+  "required": [
+    "skipped_no_default"
+  ],
+  "properties": {
+    "skipped_default": {
+      "writeOnly": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "skipped_no_default": {
+      "writeOnly": true,
+      "type": "boolean"
+    }
+  }
+}

--- a/schemars_derive/src/schema_exprs.rs
+++ b/schemars_derive/src/schema_exprs.rs
@@ -450,7 +450,8 @@ fn expr_for_struct(
 
             let (ty, type_def) = type_for_field_schema(field);
 
-            let has_default = default.is_some();
+            let has_default =
+                set_container_default.is_some() || !field.serde_attrs.default().is_none();
             let required = field.validation_attrs.required();
 
             let metadata = SchemaMetadata {


### PR DESCRIPTION
We're currently kind of stuck on schemars 0.8.22; I don't know if you're considering backported fixes, but this would be helpful to us. It uses code introduced in #330.

--

A struct field annotated with #[serde(default, skip_serializing)] (or a skip_serializing field in a container with #[serde(default)]) was emitted as a required property in the generated schema, even though deserialization does not require it.

The root cause is in expr_for_struct: field_default_expr deliberately suppresses the default value expression for skip_serializing fields, so that the schema does not advertise a default for a value that is never serialized. However, has_default was computed from that suppressed expression (default.is_some()), so the suppression leaked into the required-ness decision made by insert_object_property, and the field was marked required.

Instead compute has_default directly from the serde attributes: a field has a default if it has a field-level #[serde(default)] (or default = "path") attribute, or if the container has one. This is equivalent to the old behavior for all non-skip_serializing fields, since field_default_expr returns Some under exactly those conditions for them, and it matches how schemars 1.x computes has_default. The default value remains suppressed for skip_serializing fields; only required-ness changes.

Note that a skip_serializing field without any default correctly remains required, since it must still be supplied when deserializing. No existing test fixtures changed as a result of this fix.