### PR TITLE
Skip `readOnly`/`writeOnly` annotations for `false` schemas

### DIFF
--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -332,6 +332,15 @@ pub fn insert_metadata_property_if_nonempty(
     }
 }
 
+pub fn insert_read_write_only(schema: &mut Schema, key: &str) {
+    // `readOnly`/`writeOnly` describe which direction a value may flow, which is vacuous on
+    // the `false` schema since it allows no value in any direction. Skipping the insertion
+    // also avoids needlessly converting the schema into its object form (`{"not": {}}`).
+    if schema.as_bool() != Some(false) {
+        schema.insert(key.to_owned(), true.into());
+    }
+}
+
 pub fn insert_validation_property(
     schema: &mut Schema,
     required_type: &str,

--- a/schemars/tests/integration/contract.rs
+++ b/schemars/tests/integration/contract.rs
@@ -216,6 +216,52 @@ fn adjacently_tagged_enum() {
         .assert_matches_de_roundtrip(arbitrary_values());
 }
 
+fn false_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!(false)
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema, Deserialize, Serialize, Default)]
+struct WriteOnlyFalseSchema {
+    #[serde(default, skip_serializing)]
+    #[schemars(schema_with = "false_schema")]
+    unsatisfiable: bool,
+    #[serde(default, skip_serializing)]
+    write_only: bool,
+}
+
+#[test]
+fn write_only_false_schema() {
+    // A `skip_serializing` field whose schema is `false` should remain the literal `false`
+    // schema, with no vacuous `writeOnly` annotation, while a satisfiable `skip_serializing`
+    // field is still annotated with `writeOnly`.
+    test!(WriteOnlyFalseSchema)
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_allows_de_roundtrip([json!({}), json!({ "write_only": true })])
+        .assert_matches_de_roundtrip(arbitrary_values_except(
+            Value::is_array,
+            "structs with `#derive(Deserialize)` can technically be deserialized from sequences, but that's not intended to be used via JSON, so schemars ignores it",
+        ));
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Default)]
+struct ReadOnlyFalseSchema {
+    #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "false_schema")]
+    unsatisfiable: Option<bool>,
+    #[serde(skip_deserializing)]
+    read_only: bool,
+}
+
+#[test]
+fn read_only_false_schema() {
+    // The same applies to `readOnly` on `skip_deserializing` fields. The
+    // `skip_serializing_if` attribute keeps the implied `default` value out of
+    // the schema, so the `false` schema survives with no annotations at all.
+    test!(ReadOnlyFalseSchema).assert_snapshot();
+}
+
 #[allow(dead_code)]
 #[derive(JsonSchema, Deserialize, Serialize)]
 #[serde(

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~read_only_false_schema.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~read_only_false_schema.de.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ReadOnlyFalseSchema",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~read_only_false_schema.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~read_only_false_schema.ser.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "read_only": {
+      "default": false,
+      "readOnly": true,
+      "type": "boolean"
+    },
+    "unsatisfiable": false
+  },
+  "required": [
+    "read_only"
+  ],
+  "title": "ReadOnlyFalseSchema",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~write_only_false_schema.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~write_only_false_schema.de.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "unsatisfiable": false,
+    "write_only": {
+      "type": "boolean",
+      "writeOnly": true
+    }
+  },
+  "title": "WriteOnlyFalseSchema",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~write_only_false_schema.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/contract.rs~write_only_false_schema.ser.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WriteOnlyFalseSchema",
+  "type": "object"
+}

--- a/schemars_derive/src/ast/mod.rs
+++ b/schemars_derive/src/ast/mod.rs
@@ -120,12 +120,12 @@ impl Field<'_> {
 
         if self.serde_attrs.skip_deserializing() {
             expr.mutators.push(quote! {
-                #SCHEMA.insert("readOnly".into(), true.into());
+                schemars::_private::insert_read_write_only(&mut #SCHEMA, "readOnly");
             });
         }
         if self.serde_attrs.skip_serializing() {
             expr.mutators.push(quote! {
-                #SCHEMA.insert("writeOnly".into(), true.into());
+                schemars::_private::insert_read_write_only(&mut #SCHEMA, "writeOnly");
             });
         }
     }


### PR DESCRIPTION
A field marked with `#[serde(skip_serializing)]` gets a `"writeOnly": true` annotation in its schema. When the field's schema is the boolean `false` schema, inserting that annotation converts the schema into its equivalent object form, producing `{"not": {}, "writeOnly": true}`.

The annotation is vacuous there: `readOnly`/`writeOnly` describe which direction a value may flow between reader and writer, but the `false` schema admits no value in any direction, so there is no flow to describe. Converting to the object form is unnecessary and obscures the simpler schema.

The derive macro now applies these annotations through a new `_private::insert_read_write_only` helper, which leaves the schema untouched when it is the literal `false` schema. Both the `readOnly` (from `skip_deserializing`) and `writeOnly` (from `skip_serializing`) paths go through the helper, so all derive branches are covered.

New integration tests snapshot both cases: a `false`-schema field with `#[serde(default, skip_serializing)]` now renders as the literal `false` with no `writeOnly` and no `required` entry, while a normal satisfiable `skip_serializing` field still gets `writeOnly`.