### PR TITLE
clippy: remove from_iter_instead_of_collect lint (removed upstream)

### DIFF
--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(
     clippy::result_large_err,
     clippy::wildcard_imports,
-    clippy::from_iter_instead_of_collect,
     clippy::too_many_lines
 )]
 


### PR DESCRIPTION
## Summary

`clippy::from_iter_instead_of_collect` has been removed from clippy.
This causes `unknown lint` errors on newer toolchains.

Remove it from the allowed list in `schemars_derive/src/lib.rs`.

## Verification

`cargo check -p schemars_derive` no longer emits `unknown lint` warnings.