### PR TITLE
Support serde_valid validation attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           cargo add --dev garde --git https://github.com/jprochazk/garde.git --rev be00ddddf8de14530ee890ccfdbaf0b13fb32852
           cargo add --dev validator@0.19
+          # serde_valid pulls unicode-segmentation; 1.13+ requires rustc 1.85+
+          cargo update -p unicode-segmentation --precise 1.12.0
         working-directory: ./schemars
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Support for [serde_valid](https://github.com/yassun7010/serde_valid) `#[validate(...)]` attributes (and equivalent `#[schemars(...)]` forms), including `minimum`/`maximum`/`exclusive_minimum`/`exclusive_maximum`/`multiple_of`, `min_length`/`max_length`, `min_items`/`max_items`/`unique_items`, `min_properties`/`max_properties`, `pattern = ...`, and `r#enum = [...]` (https://github.com/GREsau/schemars/issues/362)
+
 ## [1.2.2] - 2026-07-27
 
 - Update to syn 3 in schemars_derive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -574,6 +574,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1036,6 +1045,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "serde_valid",
  "smallvec",
  "smol_str 0.2.2",
  "smol_str 0.3.2",
@@ -1146,6 +1156,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_valid"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c27ca2c5a9c81bfec81f36f1e525df8d4e50167a47e42f5452e66c70e5ee78"
+dependencies = [
+ "indexmap",
+ "itertools",
+ "num-traits",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_valid_derive",
+ "serde_valid_literal",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "serde_valid_derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8650434c776ef940286911d687c8da1ddc47ae90caf79c8bede38badcdb7698e"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_valid_literal"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a7f040bcddf2a5b9e1da609ed7e2f82bce3b5ffcb3ca710f0a51ca74d65dae"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1273,11 +1323,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1360,6 +1430,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "url"

--- a/docs/_includes/attributes.md
+++ b/docs/_includes/attributes.md
@@ -16,7 +16,7 @@ pub struct MyStruct {
 }
 ```
 
-[Validator](https://github.com/Keats/validator) and [Garde](https://github.com/jprochazk/garde) allow setting `#[validate(...)]`/`#[garde(...)]` attributes to restrict valid values of particular fields, many of which will be used by Schemars to generate more accurate schemas. These can also be overridden by `#[schemars(...)]` attributes.
+[Validator](https://github.com/Keats/validator), [Garde](https://github.com/jprochazk/garde), and [serde_valid](https://github.com/yassun7010/serde_valid) allow setting `#[validate(...)]`/`#[garde(...)]` attributes to restrict valid values of particular fields, many of which will be used by Schemars to generate more accurate schemas. These can also be overridden by `#[schemars(...)]` attributes.
 
 <details open>
 <summary style="font-weight: bold">
@@ -39,13 +39,18 @@ TABLE OF CONTENTS
    - [`deny_unknown_fields`](#deny_unknown_fields)
    - [`transparent`](#transparent)
    - [`bound`](#bound)
-1. [Supported Validator/Garde Attributes](#supported-validatorgarde-attributes)
+1. [Supported Validator/Garde/serde_valid Attributes](#supported-validatorgardeserde_valid-attributes)
    - [`email` / `url` / `ip` / `ipv4` / `ipv6`](#formats)
    - [`length`](#length)
    - [`range`](#range)
    - [`regex` / `pattern`](#regex)
    - [`contains`](#contains)
    - [`required`](#required)
+   - [`minimum` / `maximum` / `exclusive_minimum` / `exclusive_maximum` / `multiple_of`](#serde_valid_numeric)
+   - [`min_length` / `max_length`](#serde_valid_length)
+   - [`min_items` / `max_items` / `unique_items`](#serde_valid_items)
+   - [`min_properties` / `max_properties`](#serde_valid_properties)
+   - [`enum`](#serde_valid_enum)
    - [`inner`](#inner)
 1. [Other Attributes](#other-attributes)
    - [`schema_with`](#schema_with)
@@ -225,7 +230,7 @@ Serde docs: [container](https://serde.rs/container-attrs.html#bound)
 
 </div>
 
-## Supported Validator/Garde Attributes
+## Supported Validator/Garde/serde_valid Attributes
 
 <div class="indented">
 
@@ -268,13 +273,16 @@ Validator docs: [range](https://github.com/Keats/validator#range)
 
 `#[validate(regex(path = *static_regex)]`<br />
 `#[schemars(regex(pattern = r"^\d+$"))]` / `#[schemars(regex(pattern = *static_regex))]`<br />
-`#[garde(pattern(r"^\d+$")]` / `#[schemars(pattern(r"^\d+$")]`/ `#[schemars(pattern(*static_regex)]`
+`#[garde(pattern(r"^\d+$")]` / `#[schemars(pattern(r"^\d+$")]`/ `#[schemars(pattern(*static_regex)]`<br />
+`#[validate(pattern = r"^\d+$")]` / `#[schemars(pattern = r"^\d+$")]`
 
 </h3>
 
 Sets the `pattern` property for string schemas. The `static_regex` will typically refer to a [`Regex`](https://docs.rs/regex/*/regex/struct.Regex.html) instance, but Schemars allows it to be any value with a `to_string()` method.
 
 `regex(pattern = ...)` is a Schemars extension, and not currently supported by the Validator crate. When using this form (or the Garde-style `pattern` attribute), you may want to use a `r"raw string literal"` so that `\\` characters in the regex pattern are not interpreted as escape sequences in the string. Using the `path = ...` form is not allowed in a `#[schemars(...)]` attribute.
+
+The `pattern = ...` form is used by [serde_valid](https://docs.rs/serde_valid/latest/serde_valid/).
 
 Validator docs: [regex](https://github.com/Keats/validator#regex)
 
@@ -299,6 +307,68 @@ When set on an `Option<T>` field, this will create a schemas as though the field
 
 Validator docs: [required](https://github.com/Keats/validator#required)
 
+<h3 id="serde_valid_numeric">
+
+`#[validate(minimum = 0)]` / `#[schemars(minimum = 0)]`<br />
+`#[validate(maximum = 10)]` / `#[schemars(maximum = 10)]`<br />
+`#[validate(exclusive_minimum = 0)]` / `#[schemars(exclusive_minimum = 0)]`<br />
+`#[validate(exclusive_maximum = 10)]` / `#[schemars(exclusive_maximum = 10)]`<br />
+`#[validate(multiple_of = 5)]` / `#[schemars(multiple_of = 5)]`
+
+</h3>
+
+Sets the corresponding numeric JSON Schema keywords. When set on an array or map field, these are applied to each item/value (matching [serde_valid](https://docs.rs/serde_valid/latest/serde_valid/) behaviour).
+
+Unlike Validator/Garde-style attributes, [serde_valid](https://docs.rs/serde_valid/latest/serde_valid/) accepts **one validator per `#[validate(...)]` attribute** (e.g. separate `minimum` and `maximum` attributes, not `#[validate(minimum = 0, maximum = 10)]`). An optional second item may be a custom message (`message` / `message_fn`); these are ignored when generating schemas.
+
+serde_valid docs: [Validations](https://docs.rs/serde_valid/latest/serde_valid/#validations)
+
+<h3 id="serde_valid_length">
+
+`#[validate(min_length = 1)]` / `#[schemars(min_length = 1)]`<br />
+`#[validate(max_length = 10)]` / `#[schemars(max_length = 10)]`
+
+</h3>
+
+Sets the `minLength`/`maxLength` properties for string schemas. When set on an array or map field, these are applied to each item/value. As with other `serde_valid` attributes, use one validator per `#[validate(...)]`.
+
+serde_valid docs: [Validations](https://docs.rs/serde_valid/latest/serde_valid/#validations)
+
+<h3 id="serde_valid_items">
+
+`#[validate(min_items = 1)]` / `#[schemars(min_items = 1)]`<br />
+`#[validate(max_items = 10)]` / `#[schemars(max_items = 10)]`<br />
+`#[validate(unique_items)]` / `#[schemars(unique_items)]`
+
+</h3>
+
+Sets the `minItems`/`maxItems`/`uniqueItems` properties for array schemas. Optional `serde_valid` message forms such as `#[validate(min_items = 1, message = "...")]` / `message_fn = ...` are accepted and ignored for schema generation.
+
+serde_valid docs: [Validations](https://docs.rs/serde_valid/latest/serde_valid/#validations)
+
+<h3 id="serde_valid_properties">
+
+`#[validate(min_properties = 1)]` / `#[schemars(min_properties = 1)]`<br />
+`#[validate(max_properties = 10)]` / `#[schemars(max_properties = 10)]`
+
+</h3>
+
+Sets the `minProperties`/`maxProperties` properties for object schemas.
+
+serde_valid docs: [Validations](https://docs.rs/serde_valid/latest/serde_valid/#validations)
+
+<h3 id="serde_valid_enum">
+
+`#[validate(r#enum = [1, 2, 3])]` / `#[schemars(r#enum = [1, 2, 3])]`
+
+</h3>
+
+Sets the `enum` property. When set on an array or map field, these are applied to each item/value.
+
+`#[validate(custom = ...)]` (field or container) is accepted by Schemars but does not affect the generated schema.
+
+serde_valid docs: [Validations](https://docs.rs/serde_valid/latest/serde_valid/#validations)
+
 </div>
 
 <h3 id="inner">
@@ -307,7 +377,7 @@ Validator docs: [required](https://github.com/Keats/validator#required)
 
 </h3>
 
-Sets properties specified by [validation attributes](#supported-validatorgarde-attributes) on items of an array schema. For example:
+Sets properties specified by [validation attributes](#supported-validatorgardeserde_valid-attributes) on items of an array schema. For example:
 
 ```rust
 struct Struct {

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -38,12 +38,13 @@ uuid1 = { version = "1.0", default-features = false, optional = true, package = 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
 trybuild = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 jsonschema = { version = "0.30", default-features = false }
 snapbox = { version = "0.6.17", features = ["json"] }
 serde_repr = "0.1.19"
 garde = { version = "0.23", features = ["derive", "email", "regex", "url"] }
 validator = { version = "0.21", features = ["derive"] }
+serde_valid = { version = "3.1.2", default-features = false }
 regex = { version = "1.10.6", default-features = false }
 
 arrayvec07 = { version = "0.7", default-features = false, features = ["serde"], package = "arrayvec" }

--- a/schemars/src/_private/mod.rs
+++ b/schemars/src/_private/mod.rs
@@ -343,6 +343,41 @@ pub fn insert_validation_property(
     }
 }
 
+/// Like [`insert_validation_property`], but if the schema is an array/map then the property is
+/// applied to each item/value schema instead. This matches `serde_valid`'s behaviour of applying
+/// value-level validations to each element of a collection.
+pub fn insert_validation_property_or_items(
+    schema: &mut Schema,
+    required_type: &str,
+    key: &str,
+    value: impl Into<Value>,
+) {
+    let value = value.into();
+    if schema.has_type(required_type) || (required_type == "number" && schema.has_type("integer")) {
+        schema.insert(key.to_owned(), value);
+        return;
+    }
+
+    for_each_item_or_property_schema(schema, |inner_schema| {
+        insert_validation_property(inner_schema, required_type, key, value.clone());
+    });
+}
+
+/// Inserts an `enum` validation property. For array/map schemas, applies to each item/value
+/// (matching `serde_valid`), otherwise applies to the schema itself.
+pub fn insert_enum_validation(schema: &mut Schema, values: Value) {
+    let mut applied_inner = false;
+
+    for_each_item_or_property_schema(schema, |inner_schema| {
+        inner_schema.insert("enum".to_owned(), values.clone());
+        applied_inner = true;
+    });
+
+    if !applied_inner {
+        schema.insert("enum".to_owned(), values);
+    }
+}
+
 pub fn must_contain(schema: &mut Schema, substring: &str) {
     let escaped = regex_syntax::escape(substring);
     insert_validation_property(schema, "string", "pattern", escaped);
@@ -351,6 +386,20 @@ pub fn must_contain(schema: &mut Schema, substring: &str) {
 pub fn apply_inner_validation(schema: &mut Schema, f: fn(&mut Schema) -> ()) {
     if let Some(inner_schema) = schema.get_mut("items").and_then(|i| i.try_into().ok()) {
         f(inner_schema);
+    }
+}
+
+fn for_each_item_or_property_schema(schema: &mut Schema, mut f: impl FnMut(&mut Schema)) {
+    if let Some(inner_schema) = schema.get_mut("items").and_then(|i| i.try_into().ok()) {
+        f(inner_schema);
+    }
+    // Only apply to object schemas — skip bools like `additionalProperties: false`.
+    if let Some(ap) = schema.get_mut("additionalProperties") {
+        if ap.is_object() {
+            if let Ok(inner_schema) = <&mut Schema>::try_from(&mut *ap) {
+                f(inner_schema);
+            }
+        }
     }
 }
 

--- a/schemars/tests/integration/main.rs
+++ b/schemars/tests/integration/main.rs
@@ -43,6 +43,7 @@ mod schema_name;
 mod schema_with;
 #[cfg(feature = "semver1")]
 mod semver;
+mod serde_valid;
 mod settings;
 mod skip;
 #[cfg(feature = "smallvec1")]

--- a/schemars/tests/integration/serde_valid.rs
+++ b/schemars/tests/integration/serde_valid.rs
@@ -1,0 +1,390 @@
+#![allow(clippy::redundant_closure)] // serde_valid custom closure forms are intentional
+
+use crate::prelude::*;
+use serde_valid::Validate;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+fn always_ok(_val: &i32) -> Result<(), serde_valid::validation::Error> {
+    Ok(())
+}
+
+fn always_ok_str(_val: &str) -> Result<(), serde_valid::validation::Error> {
+    Ok(())
+}
+
+fn min_error_message(_params: &serde_valid::MinItemsError) -> String {
+    "too few items".to_owned()
+}
+
+fn max_error_message(_params: &serde_valid::MaxItemsError) -> String {
+    "too many items".to_owned()
+}
+
+fn sample_struct_rule(val: i32) -> Result<(), serde_valid::validation::Error> {
+    if val >= 0 {
+        Ok(())
+    } else {
+        Err(serde_valid::validation::Error::Custom(
+            "must be non-negative".to_owned(),
+        ))
+    }
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Validate)]
+#[validate(custom = |s| sample_struct_rule(s.min_max as i32))]
+pub struct SerdeValidAttrStruct {
+    // serde_valid: one validator per `#[validate(...)]` (not `minimum = 1, maximum = 100`)
+    #[validate(minimum = 1.0)]
+    #[validate(maximum = 100.0)]
+    min_max: f32,
+    #[validate(exclusive_minimum = 0.0)]
+    #[validate(exclusive_maximum = 10.0)]
+    exclusive_min_max: f32,
+    #[validate(multiple_of = 2.5)]
+    multiple: f32,
+    #[validate(pattern = r"^[Hh]ello")]
+    regex_str: String,
+    #[validate(min_length = 1)]
+    #[validate(max_length = 10)]
+    non_empty_str: String,
+    #[validate(min_items = 1)]
+    #[validate(max_items = 3)]
+    #[validate(unique_items)]
+    items: Vec<i32>,
+    // Value-level rules apply to each element of collections
+    #[validate(min_length = 2)]
+    item_lengths: Vec<String>,
+    #[validate(minimum = 0)]
+    #[validate(maximum = 10)]
+    nested_numbers: Vec<i32>,
+    #[validate(r#enum = [1, 2, 3])]
+    enum_int: i32,
+    #[validate(r#enum = ["a", "b"])]
+    enum_str: String,
+    #[validate(min_properties = 1)]
+    #[validate(max_properties = 3)]
+    props: HashMap<String, bool>,
+    // Message variants (second slot only) — ignored for schema generation
+    #[validate(min_items = 1, message_fn = min_error_message)]
+    #[validate(max_items = 5, message_fn = max_error_message)]
+    messaged_items: Vec<i32>,
+    // Custom field validation — ignored for schema generation
+    #[validate(custom = always_ok)]
+    #[validate(custom = |v| always_ok(v))]
+    custom_int: i32,
+    // Nested dive
+    #[validate]
+    nested: SerdeValidNested,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Validate, Default)]
+pub struct SerdeValidNested {
+    #[validate(minimum = -100)]
+    #[validate(maximum = 100)]
+    x: i32,
+}
+
+impl Default for SerdeValidAttrStruct {
+    fn default() -> Self {
+        Self {
+            min_max: 1.0,
+            exclusive_min_max: 5.0,
+            multiple: 5.0,
+            regex_str: "Hello world".to_owned(),
+            non_empty_str: "test".to_owned(),
+            items: vec![1, 2],
+            item_lengths: vec!["ab".to_owned(), "cd".to_owned()],
+            nested_numbers: vec![0, 10],
+            enum_int: 1,
+            enum_str: "a".to_owned(),
+            props: HashMap::from([("x".to_owned(), true)]),
+            messaged_items: vec![1],
+            custom_int: 0,
+            nested: SerdeValidNested { x: 0 },
+        }
+    }
+}
+
+impl SerdeValidAttrStruct {
+    pub fn invalid_values() -> impl IntoIterator<Item = Self> {
+        static MUTATORS: &[fn(&mut SerdeValidAttrStruct)] = &[
+            |v| v.min_max = 0.9,
+            |v| v.min_max = 100.1,
+            |v| v.exclusive_min_max = 0.0,
+            |v| v.exclusive_min_max = 10.0,
+            |v| v.multiple = 3.0,
+            |v| v.regex_str = "fail".to_owned(),
+            |v| v.non_empty_str = String::new(),
+            |v| v.items = Vec::new(),
+            |v| v.items = vec![1, 2, 3, 4],
+            |v| v.items = vec![1, 1],
+            |v| v.item_lengths = vec!["a".to_owned()],
+            |v| v.nested_numbers = vec![-1],
+            |v| v.nested_numbers = vec![11],
+            |v| v.enum_int = 4,
+            |v| v.enum_str = "c".to_owned(),
+            |v| v.props = HashMap::new(),
+            |v| {
+                v.props = HashMap::from([
+                    ("a".to_owned(), true),
+                    ("b".to_owned(), true),
+                    ("c".to_owned(), true),
+                    ("d".to_owned(), true),
+                ])
+            },
+            |v| v.messaged_items = Vec::new(),
+            |v| v.messaged_items = vec![1, 2, 3, 4, 5, 6],
+            |v| v.nested.x = -101,
+            |v| v.nested.x = 101,
+        ];
+        MUTATORS.iter().map(|f| {
+            let mut result = SerdeValidAttrStruct::default();
+            f(&mut result);
+            result
+        })
+    }
+}
+
+#[test]
+fn serde_valid_attrs() {
+    test!(SerdeValidAttrStruct)
+        .with_validator(|v| v.validate().is_ok())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_rejects_invalid(SerdeValidAttrStruct::invalid_values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+// Mirror serde_valid style: one keyword per `#[schemars(...)]` attribute.
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "SerdeValidAttrStruct")]
+pub struct SchemarsAttrStruct {
+    #[schemars(minimum = 1.0)]
+    #[schemars(maximum = 100.0)]
+    min_max: f32,
+    #[schemars(exclusive_minimum = 0.0)]
+    #[schemars(exclusive_maximum = 10.0)]
+    exclusive_min_max: f32,
+    #[schemars(multiple_of = 2.5)]
+    multiple: f32,
+    #[schemars(pattern = r"^[Hh]ello")]
+    regex_str: String,
+    #[schemars(min_length = 1)]
+    #[schemars(max_length = 10)]
+    non_empty_str: String,
+    #[schemars(min_items = 1)]
+    #[schemars(max_items = 3)]
+    #[schemars(unique_items)]
+    items: Vec<i32>,
+    #[schemars(min_length = 2)]
+    item_lengths: Vec<String>,
+    #[schemars(minimum = 0)]
+    #[schemars(maximum = 10)]
+    nested_numbers: Vec<i32>,
+    #[schemars(r#enum = [1, 2, 3])]
+    enum_int: i32,
+    #[schemars(r#enum = ["a", "b"])]
+    enum_str: String,
+    #[schemars(min_properties = 1)]
+    #[schemars(max_properties = 3)]
+    props: HashMap<String, bool>,
+    #[schemars(min_items = 1)]
+    #[schemars(max_items = 5)]
+    messaged_items: Vec<i32>,
+    custom_int: i32,
+    nested: SchemarsNested,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename = "SerdeValidNested")]
+pub struct SchemarsNested {
+    #[schemars(minimum = -100)]
+    #[schemars(maximum = 100)]
+    x: i32,
+}
+
+#[test]
+fn schemars_attrs() {
+    test!(SchemarsAttrStruct).assert_identical::<SerdeValidAttrStruct>();
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Validate)]
+pub struct SerdeValidAttrTuple(
+    #[validate(maximum = 10)] u8,
+    #[validate(min_length = 1)] String,
+);
+
+#[test]
+fn serde_valid_attrs_tuple() {
+    test!(SerdeValidAttrTuple)
+        .with_validator(|v| v.validate().is_ok())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([SerdeValidAttrTuple(10, "a".to_owned())])
+        .assert_rejects_invalid([
+            SerdeValidAttrTuple(11, "a".to_owned()),
+            SerdeValidAttrTuple(10, String::new()),
+        ])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Validate)]
+pub struct SerdeValidAttrNewType(#[validate(maximum = 10)] u8);
+
+#[test]
+fn serde_valid_attrs_newtype() {
+    test!(SerdeValidAttrNewType)
+        .with_validator(|v| v.validate().is_ok())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([SerdeValidAttrNewType(10)])
+        .assert_rejects_invalid([SerdeValidAttrNewType(11)])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+/// Custom validation forms that must compile and be ignored for schema output.
+#[derive(JsonSchema, Deserialize, Serialize, Validate)]
+#[validate(custom = |s| always_ok(&s.value))]
+pub struct SerdeValidCustomForms {
+    #[validate(custom = always_ok)]
+    #[validate(custom(always_ok))]
+    #[validate(custom = |v| always_ok(v))]
+    value: i32,
+    #[validate(minimum = 0, message = "too small")]
+    #[validate(maximum = 10, message_fn = |_| "too large".to_owned())]
+    bounded: i32,
+    #[validate(pattern = r"^\w+$", message = "bad pattern")]
+    #[validate(custom = always_ok_str)]
+    named: String,
+}
+
+#[test]
+fn serde_valid_custom_and_message_forms() {
+    test!(SerdeValidCustomForms)
+        .with_validator(|v| v.validate().is_ok())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip([SerdeValidCustomForms {
+            value: 1,
+            bounded: 5,
+            named: "ok".to_owned(),
+        }])
+        .assert_rejects_invalid([
+            SerdeValidCustomForms {
+                value: 1,
+                bounded: -1,
+                named: "ok".to_owned(),
+            },
+            SerdeValidCustomForms {
+                value: 1,
+                bounded: 11,
+                named: "ok".to_owned(),
+            },
+            SerdeValidCustomForms {
+                value: 1,
+                bounded: 5,
+                named: "bad name".to_owned(),
+            },
+        ])
+        .assert_matches_de_roundtrip(arbitrary_values());
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Validate, Clone)]
+pub struct SerdeValidWrapperInner {
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    n: i32,
+}
+
+/// Wrapper / pointer compositions supported by serde_valid composited validation.
+#[allow(clippy::box_collection)] // intentionally tests `Box<Vec<_>>` composition
+#[derive(JsonSchema, Deserialize, Serialize, Validate)]
+pub struct SerdeValidWrapperFields {
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    boxed: Box<i32>,
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    rc: Rc<i32>,
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    arc: Arc<i32>,
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    optional: Option<i32>,
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    optional_box: Option<Box<i32>>,
+    #[validate(minimum = 1)]
+    #[validate(maximum = 10)]
+    box_optional: Box<Option<i32>>,
+    #[validate(min_items = 1)]
+    #[validate(max_items = 3)]
+    #[allow(clippy::box_collection)] // intentionally tests `Box<Vec<_>>` composition
+    boxed_vec: Box<Vec<i32>>,
+    #[validate(min_length = 2)]
+    rc_strings: Rc<Vec<String>>,
+    #[validate]
+    nested_box: Box<SerdeValidWrapperInner>,
+    #[validate]
+    nested_rc: Rc<SerdeValidWrapperInner>,
+    #[validate]
+    nested_optional_box: Option<Box<SerdeValidWrapperInner>>,
+}
+
+impl Default for SerdeValidWrapperFields {
+    fn default() -> Self {
+        Self {
+            boxed: Box::new(5),
+            rc: Rc::new(5),
+            arc: Arc::new(5),
+            optional: Some(5),
+            optional_box: Some(Box::new(5)),
+            box_optional: Box::new(Some(5)),
+            boxed_vec: Box::new(vec![1, 2]),
+            rc_strings: Rc::new(vec!["ab".to_owned()]),
+            nested_box: Box::new(SerdeValidWrapperInner { n: 5 }),
+            nested_rc: Rc::new(SerdeValidWrapperInner { n: 5 }),
+            nested_optional_box: Some(Box::new(SerdeValidWrapperInner { n: 5 })),
+        }
+    }
+}
+
+impl SerdeValidWrapperFields {
+    fn invalid_values() -> impl IntoIterator<Item = Self> {
+        static MUTATORS: &[fn(&mut SerdeValidWrapperFields)] = &[
+            |v| *v.boxed = 0,
+            |v| v.rc = Rc::new(11),
+            |v| v.arc = Arc::new(0),
+            |v| v.optional = Some(0),
+            |v| v.optional_box = Some(Box::new(11)),
+            |v| *v.box_optional = Some(0),
+            |v| *v.boxed_vec = Vec::new(),
+            |v| *v.boxed_vec = vec![1, 2, 3, 4],
+            |v| *Rc::make_mut(&mut v.rc_strings) = vec!["a".to_owned()],
+            |v| v.nested_box.n = 0,
+            |v| Rc::make_mut(&mut v.nested_rc).n = 11,
+            |v| {
+                if let Some(inner) = v.nested_optional_box.as_mut() {
+                    inner.n = 0;
+                }
+            },
+        ];
+        MUTATORS.iter().map(|f| {
+            let mut result = SerdeValidWrapperFields::default();
+            f(&mut result);
+            result
+        })
+    }
+}
+
+#[test]
+fn serde_valid_wrapper_fields() {
+    test!(SerdeValidWrapperFields)
+        .with_validator(|v| v.validate().is_ok())
+        .assert_snapshot()
+        .assert_allows_ser_roundtrip_default()
+        .assert_rejects_invalid(SerdeValidWrapperFields::invalid_values())
+        .assert_matches_de_roundtrip(arbitrary_values());
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs.json
@@ -1,0 +1,131 @@
+{
+  "$defs": {
+    "SerdeValidNested": {
+      "properties": {
+        "x": {
+          "format": "int32",
+          "maximum": 100,
+          "minimum": -100,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "x"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "custom_int": {
+      "format": "int32",
+      "type": "integer"
+    },
+    "enum_int": {
+      "enum": [
+        1,
+        2,
+        3
+      ],
+      "format": "int32",
+      "type": "integer"
+    },
+    "enum_str": {
+      "enum": [
+        "a",
+        "b"
+      ],
+      "type": "string"
+    },
+    "exclusive_min_max": {
+      "exclusiveMaximum": 10.0,
+      "exclusiveMinimum": 0.0,
+      "format": "float",
+      "type": "number"
+    },
+    "item_lengths": {
+      "items": {
+        "minLength": 2,
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "items": {
+      "items": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "maxItems": 3,
+      "minItems": 1,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "messaged_items": {
+      "items": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "maxItems": 5,
+      "minItems": 1,
+      "type": "array"
+    },
+    "min_max": {
+      "format": "float",
+      "maximum": 100.0,
+      "minimum": 1.0,
+      "type": "number"
+    },
+    "multiple": {
+      "format": "float",
+      "multipleOf": 2.5,
+      "type": "number"
+    },
+    "nested": {
+      "$ref": "#/$defs/SerdeValidNested"
+    },
+    "nested_numbers": {
+      "items": {
+        "format": "int32",
+        "maximum": 10,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "non_empty_str": {
+      "maxLength": 10,
+      "minLength": 1,
+      "type": "string"
+    },
+    "props": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "maxProperties": 3,
+      "minProperties": 1,
+      "type": "object"
+    },
+    "regex_str": {
+      "pattern": "^[Hh]ello",
+      "type": "string"
+    }
+  },
+  "required": [
+    "min_max",
+    "exclusive_min_max",
+    "multiple",
+    "regex_str",
+    "non_empty_str",
+    "items",
+    "item_lengths",
+    "nested_numbers",
+    "enum_int",
+    "enum_str",
+    "props",
+    "messaged_items",
+    "custom_int",
+    "nested"
+  ],
+  "title": "SerdeValidAttrStruct",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs_newtype.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs_newtype.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "format": "uint8",
+  "maximum": 10,
+  "minimum": 0,
+  "title": "SerdeValidAttrNewType",
+  "type": "integer"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs_tuple.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_attrs_tuple.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "maxItems": 2,
+  "minItems": 2,
+  "prefixItems": [
+    {
+      "format": "uint8",
+      "maximum": 10,
+      "minimum": 0,
+      "type": "integer"
+    },
+    {
+      "minLength": 1,
+      "type": "string"
+    }
+  ],
+  "title": "SerdeValidAttrTuple",
+  "type": "array"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_custom_and_message_forms.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_custom_and_message_forms.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Custom validation forms that must compile and be ignored for schema output.",
+  "properties": {
+    "bounded": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "named": {
+      "pattern": "^\\w+$",
+      "type": "string"
+    },
+    "value": {
+      "format": "int32",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "value",
+    "bounded",
+    "named"
+  ],
+  "title": "SerdeValidCustomForms",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_wrapper_fields.de.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_wrapper_fields.de.json
@@ -1,0 +1,110 @@
+{
+  "$defs": {
+    "SerdeValidWrapperInner": {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "maximum": 10,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "n"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Wrapper / pointer compositions supported by serde_valid composited validation.",
+  "properties": {
+    "arc": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "box_optional": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "boxed": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "boxed_vec": {
+      "items": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "maxItems": 3,
+      "minItems": 1,
+      "type": "array"
+    },
+    "nested_box": {
+      "$ref": "#/$defs/SerdeValidWrapperInner"
+    },
+    "nested_optional_box": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SerdeValidWrapperInner"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nested_rc": {
+      "$ref": "#/$defs/SerdeValidWrapperInner"
+    },
+    "optional": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "optional_box": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "rc": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "rc_strings": {
+      "items": {
+        "minLength": 2,
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "boxed",
+    "rc",
+    "arc",
+    "boxed_vec",
+    "rc_strings",
+    "nested_box",
+    "nested_rc"
+  ],
+  "title": "SerdeValidWrapperFields",
+  "type": "object"
+}

--- a/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_wrapper_fields.ser.json
+++ b/schemars/tests/integration/snapshots/schemars/tests/integration/serde_valid.rs~serde_valid_wrapper_fields.ser.json
@@ -1,0 +1,114 @@
+{
+  "$defs": {
+    "SerdeValidWrapperInner": {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "maximum": 10,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "n"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Wrapper / pointer compositions supported by serde_valid composited validation.",
+  "properties": {
+    "arc": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "box_optional": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "boxed": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "boxed_vec": {
+      "items": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "maxItems": 3,
+      "minItems": 1,
+      "type": "array"
+    },
+    "nested_box": {
+      "$ref": "#/$defs/SerdeValidWrapperInner"
+    },
+    "nested_optional_box": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SerdeValidWrapperInner"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nested_rc": {
+      "$ref": "#/$defs/SerdeValidWrapperInner"
+    },
+    "optional": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "optional_box": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "rc": {
+      "format": "int32",
+      "maximum": 10,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "rc_strings": {
+      "items": {
+        "minLength": 2,
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "boxed",
+    "rc",
+    "arc",
+    "optional",
+    "optional_box",
+    "box_optional",
+    "boxed_vec",
+    "rc_strings",
+    "nested_box",
+    "nested_rc",
+    "nested_optional_box"
+  ],
+  "title": "SerdeValidWrapperFields",
+  "type": "object"
+}

--- a/schemars_derive/Cargo.toml
+++ b/schemars_derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.91"
 quote = "1.0.35"
-syn = "3"
+syn = { version = "3", features = ["full"] }
 serde_derive_internals = "0.30.0"
 
 [dev-dependencies]

--- a/schemars_derive/src/attr/validation.rs
+++ b/schemars_derive/src/attr/validation.rs
@@ -5,7 +5,8 @@ use crate::{idents::SCHEMA, schema_exprs::SchemaExpr};
 
 use super::{
     parse_meta::{
-        parse_contains, parse_length_or_range, parse_nested_meta, parse_pattern,
+        parse_contains, parse_length_or_range, parse_name_value_expr,
+        parse_name_value_expr_handle_lit_str, parse_nested_meta, parse_pattern,
         parse_schemars_regex, parse_validate_regex, require_path_only, LengthOrRange,
     },
     AttrCtxt, CustomMeta,
@@ -55,6 +56,7 @@ impl Format {
 
 #[derive(Default)]
 pub struct ValidationAttrs {
+    // validator/garde style keywords
     pub length: Option<LengthOrRange>,
     pub range: Option<LengthOrRange>,
     pub pattern: Option<Expr>,
@@ -63,6 +65,20 @@ pub struct ValidationAttrs {
     pub required: bool,
     pub format: Option<Format>,
     pub inner: Option<Box<ValidationAttrs>>,
+    // serde_valid style keywords
+    pub minimum: Option<Expr>,
+    pub maximum: Option<Expr>,
+    pub exclusive_minimum: Option<Expr>,
+    pub exclusive_maximum: Option<Expr>,
+    pub multiple_of: Option<Expr>,
+    pub min_length: Option<Expr>,
+    pub max_length: Option<Expr>,
+    pub min_items: Option<Expr>,
+    pub max_items: Option<Expr>,
+    pub unique_items: bool,
+    pub min_properties: Option<Expr>,
+    pub max_properties: Option<Expr>,
+    pub enumeration: Option<Expr>,
 }
 
 impl ValidationAttrs {
@@ -80,9 +96,18 @@ impl ValidationAttrs {
             Self::add_length_or_range(range, mutators, "number", "imum", mut_ref_schema);
         }
 
-        if let Some(regex) = self.regex.as_ref().or(self.pattern.as_ref()) {
+        // `regex` (validator/schemars) only applies to string schemas.
+        if let Some(regex) = &self.regex {
             mutators.push(quote! {
                 schemars::_private::insert_validation_property(#mut_ref_schema, "string", "pattern", (#regex).to_string());
+            });
+        }
+
+        // `pattern` includes serde_valid `pattern = ...`, which applies to each collection item.
+        // On plain string schemas this behaves the same as `insert_validation_property`.
+        if let Some(pattern) = &self.pattern {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "string", "pattern", (#pattern).to_string());
             });
         }
 
@@ -96,6 +121,84 @@ impl ValidationAttrs {
             let f = format.schema_str();
             mutators.push(quote! {
                     (#mut_ref_schema).insert("format".into(), #f.into());
+            });
+        }
+
+        if let Some(minimum) = &self.minimum {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "number", "minimum", #minimum);
+            });
+        }
+
+        if let Some(maximum) = &self.maximum {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "number", "maximum", #maximum);
+            });
+        }
+
+        if let Some(exclusive_minimum) = &self.exclusive_minimum {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "number", "exclusiveMinimum", #exclusive_minimum);
+            });
+        }
+
+        if let Some(exclusive_maximum) = &self.exclusive_maximum {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "number", "exclusiveMaximum", #exclusive_maximum);
+            });
+        }
+
+        if let Some(multiple_of) = &self.multiple_of {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "number", "multipleOf", #multiple_of);
+            });
+        }
+
+        if let Some(min_length) = &self.min_length {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "string", "minLength", #min_length);
+            });
+        }
+
+        if let Some(max_length) = &self.max_length {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property_or_items(#mut_ref_schema, "string", "maxLength", #max_length);
+            });
+        }
+
+        if let Some(min_items) = &self.min_items {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property(#mut_ref_schema, "array", "minItems", #min_items);
+            });
+        }
+
+        if let Some(max_items) = &self.max_items {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property(#mut_ref_schema, "array", "maxItems", #max_items);
+            });
+        }
+
+        if let Some(min_properties) = &self.min_properties {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property(#mut_ref_schema, "object", "minProperties", #min_properties);
+            });
+        }
+
+        if let Some(max_properties) = &self.max_properties {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property(#mut_ref_schema, "object", "maxProperties", #max_properties);
+            });
+        }
+
+        if self.unique_items {
+            mutators.push(quote! {
+                schemars::_private::insert_validation_property(#mut_ref_schema, "array", "uniqueItems", true);
+            });
+        }
+
+        if let Some(enumeration) = &self.enumeration {
+            mutators.push(quote! {
+                schemars::_private::insert_enum_validation(#mut_ref_schema, schemars::_private::serde_json::json!(#enumeration));
             });
         }
 
@@ -177,14 +280,23 @@ impl ValidationAttrs {
                 }
             }
 
-            "pattern" if cx.attr_type != "validate" => {
-                match (&self.pattern, &self.regex, &self.contains) {
-                    (Some(_p), _, _) => cx.duplicate_error(&meta),
-                    (_, Some(_r), _) => cx.mutual_exclusive_error(&meta, "regex"),
-                    (_, _, Some(_c)) => cx.mutual_exclusive_error(&meta, "contains"),
-                    (None, None, None) => self.pattern = parse_pattern(&meta, cx).ok(),
-                }
-            }
+            "pattern" => match (&self.pattern, &self.regex, &self.contains) {
+                (Some(_p), _, _) => cx.duplicate_error(&meta),
+                (_, Some(_r), _) => cx.mutual_exclusive_error(&meta, "regex"),
+                (_, _, Some(_c)) => cx.mutual_exclusive_error(&meta, "contains"),
+                (None, None, None) => match &meta {
+                    // serde_valid-style: `#[validate(pattern = "...")]`
+                    // schemars also allows the NameValue form
+                    CustomMeta::NameValue(_) if cx.attr_type != "garde" => {
+                        self.pattern = parse_name_value_expr(meta, cx).ok();
+                    }
+                    // garde/schemars-style: `pattern(...)`
+                    CustomMeta::List(_) if cx.attr_type != "validate" => {
+                        self.pattern = parse_pattern(&meta, cx).ok();
+                    }
+                    _ => return Err(meta),
+                },
+            },
             "regex" if cx.attr_type != "garde" => {
                 match (&self.pattern, &self.regex, &self.contains) {
                     (Some(_p), _, _) => cx.mutual_exclusive_error(&meta, "pattern"),
@@ -215,6 +327,73 @@ impl ValidationAttrs {
                     inner.process_attr(&mut inner_cx);
                 }
             }
+
+            // serde_valid / JSON Schema keywords (also allowed on `schemars(...)`)
+            "minimum" => match self.minimum {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.minimum = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "maximum" => match self.maximum {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.maximum = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "exclusive_minimum" => match self.exclusive_minimum {
+                Some(_) => cx.duplicate_error(&meta),
+                None => {
+                    self.exclusive_minimum = parse_name_value_expr_handle_lit_str(meta, cx).ok();
+                }
+            },
+            "exclusive_maximum" => match self.exclusive_maximum {
+                Some(_) => cx.duplicate_error(&meta),
+                None => {
+                    self.exclusive_maximum = parse_name_value_expr_handle_lit_str(meta, cx).ok();
+                }
+            },
+            "multiple_of" => match self.multiple_of {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.multiple_of = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "min_length" => match self.min_length {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.min_length = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "max_length" => match self.max_length {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.max_length = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "min_items" => match self.min_items {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.min_items = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "max_items" => match self.max_items {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.max_items = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "min_properties" => match self.min_properties {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.min_properties = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "max_properties" => match self.max_properties {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.max_properties = parse_name_value_expr_handle_lit_str(meta, cx).ok(),
+            },
+            "enum" | "r#enum" => match self.enumeration {
+                Some(_) => cx.duplicate_error(&meta),
+                None => self.enumeration = parse_name_value_expr(meta, cx).ok(),
+            },
+            "unique_items" => {
+                if self.unique_items {
+                    cx.duplicate_error(&meta);
+                } else if require_path_only(&meta, cx).is_ok() {
+                    self.unique_items = true;
+                }
+            }
+
+            // serde_valid-only items that do not affect the generated schema.
+            // Recognised so that forms like `#[validate(minimum = 1, message = "...")]`
+            // and `#[validate(custom = ...)]` are accepted without error.
+            "message" | "message_fn" | "message_l10n" | "fluent" | "i18n" | "custom"
+                if cx.attr_type == "validate" => {}
 
             _ => return Err(meta),
         }
@@ -248,6 +427,19 @@ impl ValidationAttrs {
                 regex: None,
                 required: false,
                 inner: None,
+                minimum: None,
+                maximum: None,
+                exclusive_minimum: None,
+                exclusive_maximum: None,
+                multiple_of: None,
+                min_length: None,
+                max_length: None,
+                min_items: None,
+                max_items: None,
+                unique_items: false,
+                min_properties: None,
+                max_properties: None,
+                enumeration: None,
             }
         )
     }

--- a/schemars_derive/src/bound.rs
+++ b/schemars_derive/src/bound.rs
@@ -295,8 +295,11 @@ mod tests {
             ))
         );
 
-        let relevant_type_params =
-            Vec::from_iter(cont.relevant_type_params.into_iter().map(Ident::to_string));
+        let relevant_type_params = cont
+            .relevant_type_params
+            .into_iter()
+            .map(Ident::to_string)
+            .collect::<Vec<_>>();
         assert_eq!(relevant_type_params, vec!["T", "U", "V", "W", "X", "Y"]);
     }
 }

--- a/schemars_derive/src/lib.rs
+++ b/schemars_derive/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(
     clippy::result_large_err,
     clippy::wildcard_imports,
-    clippy::from_iter_instead_of_collect,
     clippy::too_many_lines
 )]
 
@@ -95,7 +94,7 @@ fn derive_json_schema(mut input: syn::DeriveInput, repr: bool) -> syn::Result<To
     }
 
     let name = cont.name();
-    let const_params = BTreeSet::from_iter(cont.generics.const_params().map(|c| &c.ident));
+    let const_params: BTreeSet<_> = cont.generics.const_params().map(|c| &c.ident).collect();
 
     // We can't just check if `cont.rename_type_params` is empty, because even if it is, there may
     // be const params in the rename format string

--- a/schemars_derive/src/name.rs
+++ b/schemars_derive/src/name.rs
@@ -22,13 +22,14 @@ pub fn get_rename_format_type_params<'a>(
         str_value = str_value.replace("}}", "");
     }
 
-    let all_const_params =
-        BTreeSet::from_iter(generics.const_params().map(|c| c.ident.to_string()));
-    let all_type_params = BTreeMap::from_iter(
-        generics
-            .type_params()
-            .map(|c| (c.ident.to_string(), &c.ident)),
-    );
+    let all_const_params: BTreeSet<_> = generics
+        .const_params()
+        .map(|c| c.ident.to_string())
+        .collect();
+    let all_type_params: BTreeMap<_, _> = generics
+        .type_params()
+        .map(|c| (c.ident.to_string(), &c.ident))
+        .collect();
 
     let mut segments = str_value.split('{');
 


### PR DESCRIPTION
Close  [#362](https://github.com/GREsau/schemars/issues/362). Add support for [serde_valid](https://github.com/yassun7010/serde_valid) `#[validate(...)]` attributes when deriving `JsonSchema`.
